### PR TITLE
Add: SIMKL rewatch tracking for scrobble

### DIFF
--- a/api/scrobblerManagementAPI.py
+++ b/api/scrobblerManagementAPI.py
@@ -74,6 +74,7 @@ WEBHOOK_SETTING_KEYS = {
     "suppress_start_at",
     "anime_mapping_crosswatch",
     "anime_mapping_simkl",
+    "simkl_rewatches",
 }
 
 
@@ -303,6 +304,8 @@ def _normalize_webhook_settings(cfg: Mapping[str, Any], provider: str, body: Map
             if key in body:
                 out[key] = bool(body.get(key))
     selected_sinks = [str(s or "").strip().lower() for s in (out.get("sinks") or _as_list(body.get("sinks")) or current_sinks)]
+    if "simkl_rewatches" in body:
+        out["simkl_rewatches"] = body.get("simkl_rewatches") is True and "simkl" in selected_sinks
     for sink in ("crosswatch", "simkl"):
         key = f"anime_mapping_{sink}"
         if key in body:
@@ -671,6 +674,18 @@ def _normalize_route_profile_id(cfg: Mapping[str, Any], value: Any) -> str:
     return ""
 
 
+def _require_simkl_rewatches(cfg: Mapping[str, Any], instance: Any, field: str) -> None:
+    from providers.scrobble.simkl import rewatches
+    from providers.scrobble.simkl.sink import _merged_provider_block, _post
+
+    projected = dict(cfg)
+    projected["simkl"] = _merged_provider_block(cfg, "simkl", instance)
+    plan, _ = rewatches.account(projected, _post)
+    if plan not in {"pro", "vip"}:
+        message = "Could not verify the SIMKL plan. Try again later." if plan == "unknown" else "Track rewatches requires SIMKL Pro or VIP."
+        raise ValidationFailure([_err(field, "simkl_rewatch_plan", message)])
+
+
 def _validate_route(cfg: Mapping[str, Any], route: dict[str, Any]) -> dict[str, Any]:
     normalized = normalize_route(route, str(route.get("id") or "R1"))
     provider = str(normalized.get("provider") or "").strip().lower()
@@ -685,6 +700,8 @@ def _validate_route(cfg: Mapping[str, Any], route: dict[str, Any]) -> dict[str, 
     _require_sink_profile(cfg, sink, str(normalized.get("sink_instance") or "default"))
     normalized["filters"] = _normalize_filters(normalized.get("filters"), provider, "filters")
     normalized["options"] = normalize_route_options(normalized.get("options"))
+    if sink == "simkl" and normalized["options"]["watch"].get("simkl_rewatches") is True:
+        _require_simkl_rewatches(cfg, normalized.get("sink_instance"), "options.watch.simkl_rewatches")
     profile_id = _normalize_route_profile_id(cfg, route.get("profile_id") or route.get("profileId") or normalized.get("profile_id"))
     if profile_id:
         normalized["profile_id"] = profile_id
@@ -758,6 +775,9 @@ def api_profile_webhook_save(request: Request, payload: dict[str, Any] = Body(..
         instance = normalize_instance_id(payload.get("provider_instance"))
         _require_source_profile(after, provider, instance)
         settings = _normalize_webhook_settings(after, provider, payload)
+        if settings.get("simkl_rewatches") is True:
+            effective = {**webhook_settings(after, provider, instance), **settings}
+            _require_simkl_rewatches(after, webhook_sink_instance(effective, "simkl"), "simkl_rewatches")
         node = _profile_override_node(after, provider, instance)
         add_sinks = settings.pop("sinks", None)
         add_insts = settings.pop("sink_instances", None)
@@ -778,6 +798,8 @@ def api_profile_webhook_save(request: Request, payload: dict[str, Any] = Body(..
             node["sink_instances"] = {k: v for k, v in insts_now.items() if k in sinks_now}
             if prev_sink in {"crosswatch", "simkl"} and prev_sink not in sinks_now:
                 node.pop(f"anime_mapping_{prev_sink}", None)
+            if prev_sink == "simkl" and prev_sink not in sinks_now:
+                node.pop("simkl_rewatches", None)
         node.update(settings)
         effective = webhook_settings(after, provider, instance)
         for sink in webhook_sinks(after, provider, instance):

--- a/assets/js/modals/scrobbler-route/index.js
+++ b/assets/js/modals/scrobbler-route/index.js
@@ -473,6 +473,7 @@ function optionsPanel(r) {
       </div>
       ${unresolvedFallback}
       ${animeMapping}
+      ${r.sink === "simkl" ? `<label class="scrm-toggle-row"><span class="scrm-toggle-copy"><span class="material-symbols-rounded">replay</span><span><strong>Track rewatches</strong><small>Allow repeat watches on this route. Requires SIMKL Pro or VIP. SIMKL applies a 48-hour gap per movie or episode. Your watched threshold still applies, with a minimum of 80%.</small></span></span><span class="scrm-switch"><input type="checkbox" id="scr-simkl-rewatches" ${r.options.watch?.simkl_rewatches === true ? "checked" : ""}><span class="scrm-switch-track"></span></span></label>` : ""}
     </section>
   `;
 }
@@ -638,6 +639,7 @@ function collect() {
   if (suppress !== "") watch.suppress_start_at = Number(suppress);
   if (provider === "plex") watch.unresolved_user_fallback = !!root.querySelector("#scr-unresolved-user-fallback")?.checked;
   if (["crosswatch", "simkl"].includes(String(root.querySelector("#scr-sink")?.value || draft.sink || "").toLowerCase())) watch.anime_mapping = !!root.querySelector("#scr-anime-mapping")?.checked;
+  if (String(root.querySelector("#scr-sink")?.value || draft.sink || "").toLowerCase() === "simkl") watch.simkl_rewatches = !!root.querySelector("#scr-simkl-rewatches")?.checked;
   const ratingsMode = root.querySelector("#scr-ratings-mode")?.value || "off";
   return {
     id: draft.id,

--- a/assets/js/modals/scrobbler-webhook/index.js
+++ b/assets/js/modals/scrobbler-webhook/index.js
@@ -551,6 +551,7 @@ function optionsPanel() {
         ${field("Suppress start", `<input class="input" id="scw-suppress" type="number" min="0" max="3600" value="${esc(settings().suppress_start_at ?? "")}" placeholder="Inherited">`)}
       </div>
       ${animeMapping}
+      ${sink === "simkl" ? `<label class="scrm-toggle-row"><span class="scrm-toggle-copy"><span class="material-symbols-rounded">replay</span><span><strong>Track rewatches</strong><small>Allow repeat watches for this destination. Requires SIMKL Pro or VIP. SIMKL applies a 48-hour gap per movie or episode. Your watched threshold still applies, with a minimum of 80%.</small></span></span><span class="scrm-switch"><input type="checkbox" id="scw-simkl-rewatches" ${settings().simkl_rewatches === true ? "checked" : ""}><span class="scrm-switch-track"></span></span></label>` : ""}
     </section>
   `;
 }
@@ -681,6 +682,7 @@ function payload() {
     if (suppress !== "") body.suppress_start_at = Number(suppress);
   }
   if (animeMappingSinks.has(sink)) body[`anime_mapping_${sink}`] = !!root.querySelector("#scw-anime-mapping")?.checked;
+  if (sink === "simkl") body.simkl_rewatches = !!root.querySelector("#scw-simkl-rewatches")?.checked;
   return body;
 }
 

--- a/providers/scrobble/routes.py
+++ b/providers/scrobble/routes.py
@@ -23,7 +23,7 @@ ROUTE_WATCH_POLICY_RANGES = {
     "pause_debounce_seconds": (0, 3600),
     "suppress_start_at": (0, 100),
 }
-ROUTE_WATCH_BOOLEAN_KEYS = {"unresolved_user_fallback", "anime_mapping"}
+ROUTE_WATCH_BOOLEAN_KEYS = {"unresolved_user_fallback", "anime_mapping", "simkl_rewatches"}
 
 
 def same_scrobble_endpoint(provider: Any, provider_instance: Any, sink: Any, sink_instance: Any) -> bool:
@@ -142,7 +142,7 @@ def normalize_route_options(options: Any) -> dict[str, Any]:
             watch[key] = val
     for key in ROUTE_WATCH_BOOLEAN_KEYS:
         if key in watch_src:
-            watch[key] = bool(watch_src.get(key))
+            watch[key] = watch_src.get(key) is True if key == "simkl_rewatches" else bool(watch_src.get(key))
 
     return {
         "auto_remove_watchlist": auto_remove,

--- a/providers/scrobble/simkl/rewatches.py
+++ b/providers/scrobble/simkl/rewatches.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+import time
+from typing import Any, Callable
+
+import requests
+
+from cw_platform.local_db.db import get_conn
+
+_LOCK = threading.RLock()
+_PLANS: dict[str, tuple[float, str, str, str, int]] = {}
+_TTL = 48 * 3600
+_PENDING = "simkl_scrobble_rewatch_pending"
+_DONE = "simkl_scrobble_rewatch_done"
+
+
+def enabled(cfg: dict[str, Any]) -> bool:
+    watch = (cfg.get("scrobble") or {}).get("watch") or {}
+    options = (watch.get("route_options") or {}).get("watch") or {}
+    return options.get("simkl_rewatches") is True
+
+
+def account_key(cfg: dict[str, Any]) -> str:
+    block = cfg.get("simkl") or {}
+    return hashlib.sha256(str(block.get("access_token") or "").encode()).hexdigest()
+
+
+def account(cfg: dict[str, Any], post: Callable[..., Any], diagnostic: Callable[..., None] | None = None) -> tuple[str, str]:
+    key = account_key(cfg)
+    with _LOCK:
+        now = time.time()
+        cached = _PLANS.get(key)
+        if cached and cached[0] > now:
+            if diagnostic:
+                diagnostic("plan", cache="hit", plan=cached[1], reason=cached[3], http_status=cached[4], expires_in_s=round(cached[0] - now))
+            return cached[1], cached[2]
+        started = time.monotonic()
+        status = 0
+        reason = "verified"
+        try:
+            response = post("/users/settings", {}, cfg)
+            status = response.status_code
+            response.raise_for_status()
+            settings = response.json()
+            plan = str(settings["account"]["type"]).lower()
+            identity = str(settings["account"].get("id") or key)
+            if plan not in {"free", "pro", "vip"}:
+                plan = "unknown"
+                reason = "invalid_plan"
+        except requests.Timeout:
+            plan, identity, reason = "unknown", key, "timeout"
+        except requests.ConnectionError:
+            plan, identity, reason = "unknown", key, "connection_error"
+        except requests.HTTPError:
+            plan, identity, reason = "unknown", key, "http_error"
+        except (ValueError, KeyError, TypeError, AttributeError):
+            plan, identity, reason = "unknown", key, "invalid_response"
+        except Exception:
+            plan, identity, reason = "unknown", key, "request_error"
+        _PLANS[key] = (now + (60 if plan == "unknown" else 300), plan, identity, reason, status)
+        if diagnostic:
+            diagnostic("plan", cache="miss", plan=plan, reason=reason, http_status=status, elapsed_ms=round((time.monotonic() - started) * 1000))
+        for old in list(_PLANS):
+            if _PLANS[old][0] <= now:
+                del _PLANS[old]
+        return plan, identity
+
+
+def downgrade(cfg: dict[str, Any]) -> None:
+    key = account_key(cfg)
+    with _LOCK:
+        identity = _PLANS.get(key, (0, "", key, "", 0))[2]
+        _PLANS[key] = (time.time() + 300, "free", identity, "pro_required", 0)
+
+
+def completion_key(cfg: dict[str, Any], ev: Any, identity: str, media: str) -> str | None:
+    session = getattr(ev, "session_key", None) or getattr(ev, "session", None)
+    if not session or str(session) == "?":
+        return None
+    watch = (cfg.get("scrobble") or {}).get("watch") or {}
+    parts = [identity, watch.get("route_provider"), watch.get("route_provider_instance", "default"),
+             watch.get("route_effective_profile_id"), getattr(ev, "server_uuid", None),
+             str(getattr(ev, "account", None) or "").casefold(), media, str(session)]
+    return hashlib.sha256(json.dumps(parts, sort_keys=True).encode()).hexdigest()
+
+
+def claim(key: str) -> str:
+    conn = get_conn()
+    if conn is None:
+        raise RuntimeError("rewatch_dedupe_unavailable")
+    now = time.time()
+    with conn:
+        conn.execute("DELETE FROM ttl_dedupe_entries WHERE namespace IN (?,?) AND expires_at<=?", (_PENDING, _DONE, now))
+        row = conn.execute("SELECT namespace FROM ttl_dedupe_entries WHERE namespace IN (?,?) AND dedupe_key=?", (_PENDING, _DONE, key)).fetchone()
+        if row:
+            return "done" if row["namespace"] == _DONE else "uncertain"
+        conn.execute("INSERT INTO ttl_dedupe_entries(namespace,dedupe_key,seen_at,expires_at,updated_at) VALUES(?,?,?,?,?)",
+                     (_PENDING, key, now, now + _TTL, time.time_ns()))
+    return "new"
+
+
+def finish(key: str, *, release: bool = False) -> None:
+    conn = get_conn()
+    if conn is None:
+        raise RuntimeError("rewatch_dedupe_unavailable")
+    with conn:
+        if release:
+            conn.execute("DELETE FROM ttl_dedupe_entries WHERE namespace=? AND dedupe_key=?", (_PENDING, key))
+        else:
+            conn.execute("UPDATE ttl_dedupe_entries SET namespace=? WHERE namespace=? AND dedupe_key=?", (_DONE, _PENDING, key))

--- a/providers/scrobble/simkl/sink.py
+++ b/providers/scrobble/simkl/sink.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
+import hashlib
 import json, time
 from pathlib import Path
 from typing import Any
@@ -23,6 +24,7 @@ except Exception:
 
 from providers.scrobble._auto_remove_watchlist import remove_across_providers_by_ids as _rm_across
 from providers.scrobble._watched_gate import resolve_stop_action
+from providers.scrobble.simkl import rewatches
 try:
     from api.watchlistAPI import remove_across_providers_by_ids as _rm_across_api
 except ImportError:
@@ -126,8 +128,11 @@ def _hdr(cfg: dict[str, Any]) -> dict[str, str]:
     return h
 
 
-def _post(path: str, body: dict[str, Any], cfg: dict[str, Any]) -> requests.Response:
-    return requests.post(f"{SIMKL_API}{path}", headers=_hdr(cfg), json=body, timeout=10)
+def _post(path: str, body: dict[str, Any], cfg: dict[str, Any], *, allow_rewatch: bool = False) -> requests.Response:
+    params = {"client_id": _hdr(cfg)["simkl-api-key"], "app-name": "CrossWatch", "app-version": _app_meta(cfg)["app_version"]}
+    if allow_rewatch and path == "/scrobble/stop" and float(body.get("progress") or 0) >= 80:
+        params["allow_rewatch"] = "yes"
+    return requests.post(f"{SIMKL_API}{path}", headers=_hdr(cfg), params=params, json=body, timeout=10)
 
 
 def _stop_pause_threshold(cfg: dict[str, Any]) -> int:
@@ -500,12 +505,36 @@ class SimklSink(ScrobbleSink):
         self._last_intent_prog: dict[str, int] = {}
         self._warn_no_token = False
         self._warn_no_key = False
+        self._rewatch_scope = ""
 
     def _route_source(self, cfg: dict[str, Any]) -> tuple[str, str]:
         watch = ((cfg.get("scrobble") or {}).get("watch") or {}) if isinstance(cfg, dict) else {}
         source = str(watch.get("route_provider") or "watcher").strip().lower() or "watcher"
         source_instance = str(watch.get("route_provider_instance") or "default").strip() or "default"
         return source, source_instance
+
+    def _rewatch_log(self, ev: Any, cfg: dict[str, Any], event: str, **fields: Any) -> None:
+        watch = (cfg.get("scrobble") or {}).get("watch") or {}
+        source, instance = self._route_source(cfg)
+        session = getattr(ev, "session_key", None) or getattr(ev, "session", None)
+        context = {
+            "route": watch.get("route_id") or "-",
+            "method": watch.get("event_method") or (getattr(ev, "raw", None) or {}).get("_cw_activity_method") or "watcher",
+            "source": source, "source_instance": instance, "destination_instance": self._instance_id,
+            "profile": watch.get("route_effective_profile_id") or "-",
+            "session_ref": hashlib.sha256(str(session).encode()).hexdigest()[:12] if session else "-",
+            "user": _mask_account(getattr(ev, "account", None)),
+            "media_type": getattr(ev, "media_type", None), "media": self._ckey(ev),
+            **fields,
+        }
+        secrets = [str((cfg.get("simkl") or {}).get(name) or "") for name in ("access_token", "api_key", "client_id")]
+        for field, value in context.items():
+            if isinstance(value, str):
+                for secret in secrets:
+                    if secret:
+                        value = value.replace(secret, "[redacted]")
+                context[field] = value
+        _log(f"rewatch.{event} " + json.dumps(context, ensure_ascii=True, separators=(",", ":")), "DEBUG")
 
     def _mkey(self, ev: Any) -> str:
         ids = getattr(ev, "ids", {}) or {}
@@ -564,7 +593,7 @@ class SimklSink(ScrobbleSink):
         except Exception:
             pass
 
-    def send(self, ev: Any, cfg: dict[str, Any] | None = None) -> None:
+    def send(self, ev: Any, cfg: dict[str, Any] | None = None) -> Any:
         cfg = cfg or (self._cfg_provider() if self._cfg_provider else None) or _cfg()
         if not isinstance(cfg, dict):
             cfg = {}
@@ -591,6 +620,17 @@ class SimklSink(ScrobbleSink):
         sess = getattr(ev, "session_key", None) or getattr(ev, "session", None)
         sk = str(sess or "?")
         mk = self._mkey(ev)
+        rewatch_mode = rewatches.enabled(cfg)
+        if rewatch_mode or action == "stop":
+            self._rewatch_log(ev, cfg, "event", enabled=rewatch_mode, action=action, progress=_clamp(getattr(ev, "progress", 0) or 0))
+        if rewatch_mode:
+            sk = json.dumps([sk, getattr(ev, "server_uuid", None), str(getattr(ev, "account", None) or "").casefold()])
+            mk = json.dumps([getattr(ev, "server_uuid", None), str(getattr(ev, "account", None) or "").casefold(), mk])
+            scope = rewatches.account_key(cfg) + json.dumps((cfg.get("scrobble") or {}).get("watch") or {}, sort_keys=True)
+            if scope != self._rewatch_scope:
+                for cache in (self._last_sent, self._p_sess, self._p_step, self._a_sess, self._p_glob, self._best, self._completed):
+                    cache.clear()
+                self._rewatch_scope = scope
 
         p_now = _clamp(getattr(ev, "progress", 0) or 0)
         force_seek = bool((getattr(ev, 'raw', None) or {}).get('_cw_seek'))
@@ -601,6 +641,11 @@ class SimklSink(ScrobbleSink):
 
         last_act = self._a_sess.get((sk, mk))
         last_bucket = self._p_step.get((sk, mk), -1)
+
+        if rewatch_mode and action == "start" and last_act == "start":
+            self._p_sess[(sk, mk)] = p_now
+            self._rewatch_log(ev, cfg, "skip", reason="unchanged_playback_state")
+            return {"ok": True, "skipped": True, "reason": "unchanged_playback_state"}
 
         if action == "start":
             self._note_watch(ev, "start", cfg, p_now)
@@ -638,9 +683,15 @@ class SimklSink(ScrobbleSink):
         thr = _stop_pause_threshold(cfg)
         last_sess = p_sess
         watched_at = _watched_at(cfg)
+        if rewatch_mode:
+            watched_at = max(80.0, watched_at)
+            if action_in == "stop":
+                p_send = p_now
         suppress_at = _watch_suppress_start_at(cfg)
 
         if action == "start" and p_send >= suppress_at:
+            if rewatch_mode:
+                self._rewatch_log(ev, cfg, "skip", reason="suppress_start", progress=p_send, threshold=suppress_at)
             _log(f"suppress start at {p_send}% (>= {suppress_at}%)", "DEBUG")
             if p_send > (p_glob if p_glob >= 0 else -1):
                 self._p_glob[mk] = p_send
@@ -656,6 +707,8 @@ class SimklSink(ScrobbleSink):
                 action = resolve_stop_action(p_send, watched_at)
                 if action == "pause":
                     _log(f"Hold STOP→PAUSE below watched_at ({p_send:.0f}% < {watched_at:.0f}%)", "DEBUG")
+            if rewatch_mode:
+                self._rewatch_log(ev, cfg, "threshold", progress=p_now, sent_progress=p_send, watched_at=watched_at, action=action)
 
         step = _progress_step(cfg)
         p_payload = int(float(p_send))
@@ -678,12 +731,36 @@ class SimklSink(ScrobbleSink):
 
         done_key = f"{sk}:{mk}"
         record_complete = action == "stop" and p_send >= watched_at
-        if record_complete and self._completed.get(done_key, -1.0) >= watched_at:
+        if not rewatch_mode and record_complete and self._completed.get(done_key, -1.0) >= watched_at:
             return
         if action_in != "stop":
             if self._debounced(sk, action, _watch_pause_debounce(cfg)):
+                if rewatch_mode:
+                    self._rewatch_log(ev, cfg, "skip", reason="debounce", action=action)
                 return
         path = {"start": "/scrobble/start", "pause": "/scrobble/pause", "stop": "/scrobble/stop"}[action]
+        completion_key = None
+        allow_rewatch = False
+        if rewatch_mode and record_complete:
+            plan, identity = rewatches.account(cfg, _post, lambda event, **fields: self._rewatch_log(ev, cfg, event, **fields))
+            if plan == "unknown":
+                self._rewatch_log(ev, cfg, "skip", reason="simkl_plan_unavailable", retryable=True)
+                return {"ok": False, "error": "simkl_plan_unavailable", "retryable": True}
+            completion_key = rewatches.completion_key(cfg, ev, identity, f"{getattr(ev, 'media_type', '')}:{self._ckey(ev)}")
+            if completion_key:
+                try:
+                    claimed = rewatches.claim(completion_key)
+                except Exception:
+                    self._rewatch_log(ev, cfg, "dedupe", decision="storage_error", retryable=False)
+                    return {"ok": False, "error": "rewatch_dedupe_unavailable", "retryable": False}
+                self._rewatch_log(ev, cfg, "dedupe", decision=claimed, retention_hours=48)
+                if claimed == "done":
+                    return {"ok": True, "skipped": True, "reason": "completion_already_processed"}
+                if claimed == "uncertain":
+                    return {"ok": False, "error": "rewatch_delivery_unconfirmed", "retryable": False}
+                allow_rewatch = plan in {"pro", "vip"}
+            reason = "eligible" if allow_rewatch else "missing_session" if not completion_key else "pro_required"
+            self._rewatch_log(ev, cfg, "eligibility", plan=plan, session_known=bool(completion_key), allow_rewatch=allow_rewatch, reason=reason)
 
         best = self._best.get(key)
         best_skel: dict[str, Any] | None = None
@@ -709,8 +786,30 @@ class SimklSink(ScrobbleSink):
                 intent_prog = int(float(body.get("progress") or p_send))
                 if self._should_log_intent(key, path, intent_prog):
                     _log(f"intent path={path} ids={_body_ids_desc(body)} p={body.get('progress')}", "DEBUG")
-            res = self._send_http(path, body, cfg)
+            if rewatch_mode:
+                self._rewatch_log(ev, cfg, "request", path=path, progress=body.get("progress"), allow_rewatch=allow_rewatch, representation=i + 1, ids=_body_ids_desc(body))
+            res = self._send_rewatch_http(path, body, cfg, allow_rewatch) if rewatch_mode else self._send_http(path, body, cfg)
+            if rewatch_mode:
+                self._rewatch_log(ev, cfg, "response", path=path, http_status=res.get("status"), outcome=res.get("diagnostic"), api_error=res.get("api_error"), elapsed_ms=res.get("elapsed_ms"))
             if res.get("ok"):
+                if rewatch_mode and record_complete:
+                    response = res.get("resp")
+                    response = response if isinstance(response, dict) else {}
+                    rewatch_status = response.get("rewatch_status")
+                    saved = response.get("action") == "scrobble" and (
+                        rewatch_status in {"active", "completed", "closed", "first_watch"}
+                        or (not allow_rewatch and rewatch_status is None)
+                    )
+                    if completion_key:
+                        self._finish_rewatch(ev, cfg, completion_key)
+                    self._rewatch_log(ev, cfg, "result", action=response.get("action"), rewatch_status=rewatch_status, saved=saved)
+                    if rewatch_status == "pro_required":
+                        rewatches.downgrade(cfg)
+                        self._rewatch_log(ev, cfg, "plan", cache="updated", plan="free", reason="pro_required")
+                    if not saved:
+                        reason = str(rewatch_status or ("pause" if response.get("action") == "pause" else "rewatch_unconfirmed"))
+                        self._note_watch(ev, action, cfg, p_send, status="skipped", reason=reason)
+                        return {"ok": True, "skipped": True, "reason": reason}
                 try:
                     act = (res.get("resp") or {}).get("action") or path.rsplit("/", 1)[-1]
                 except Exception:
@@ -752,6 +851,15 @@ class SimklSink(ScrobbleSink):
                 continue
             break
 
+        if rewatch_mode and last_err:
+            status = int(last_err.get("status") or 0)
+            reason = "duplicate_stop" if status == 409 else f"simkl_http_{status}" if status else "rewatch_delivery_unconfirmed"
+            if completion_key and 400 <= status < 500:
+                self._finish_rewatch(ev, cfg, completion_key, release=status in {400, 401, 403, 404, 423, 429})
+            self._rewatch_log(ev, cfg, "failure", path=path, reason=reason, cause=last_err.get("diagnostic"), http_status=status, retryable=False)
+            self._note_watch(ev, action, cfg, p_send, status="skipped" if status == 409 else "fail", reason=reason)
+            return {"ok": status == 409, "skipped": status == 409, "reason": reason, "error": reason, "retryable": False}
+
         if last_err and last_err.get("status") == 409 and action == "stop":
             _log("Treating 409 (duplicate stop) as watched; proceeding to auto-remove", "WARN")
             if record_complete:
@@ -775,6 +883,38 @@ class SimklSink(ScrobbleSink):
             _log(f"{path} {last_err.get('status')} err={last_err.get('resp')}", "ERROR")
             if action in ("start", "stop"):
                 self._note_watch(ev, action, cfg, p_send, status="fail", reason=str(last_err.get("status") or ""))
+
+    def _finish_rewatch(self, ev: Any, cfg: dict[str, Any], key: str, *, release: bool = False) -> None:
+        try:
+            rewatches.finish(key, release=release)
+        except Exception:
+            self._rewatch_log(ev, cfg, "dedupe", decision="storage_error", operation="release" if release else "finish")
+            raise
+        self._rewatch_log(ev, cfg, "dedupe", decision="released" if release else "finished")
+
+    def _send_rewatch_http(self, path: str, body: dict[str, Any], cfg: dict[str, Any], allow_rewatch: bool) -> dict[str, Any]:
+        started = time.monotonic()
+        try:
+            response = _post(path, body, cfg, allow_rewatch=allow_rewatch)
+            try:
+                payload = response.json()
+            except Exception:
+                payload = None
+            valid = isinstance(payload, dict) and payload.get("action") in ("start", "pause", "stop", "scrobble")
+            diagnostic = "http_error" if response.status_code >= 400 else "ok" if valid else "invalid_response"
+            error = payload.get("error") if isinstance(payload, dict) else None
+            code = error.get("code") if isinstance(error, dict) else error
+            api_error = code if code in ("RATE_LIMIT", "INVALID_TOKEN", "INVALID_CLIENT_ID", "NOT_FOUND") else None
+            return {"ok": 200 <= response.status_code < 300, "status": response.status_code, "resp": payload,
+                    "diagnostic": diagnostic, "api_error": api_error, "elapsed_ms": round((time.monotonic() - started) * 1000)}
+        except requests.Timeout:
+            diagnostic = "timeout"
+        except requests.ConnectionError:
+            diagnostic = "connection_error"
+        except Exception:
+            diagnostic = "request_error"
+        return {"ok": False, "status": 0, "resp": None, "diagnostic": diagnostic,
+                "elapsed_ms": round((time.monotonic() - started) * 1000)}
 
     def _send_http(self, path: str, body: dict[str, Any], cfg: dict[str, Any]) -> dict[str, Any]:
         backoff = 1.0

--- a/providers/webhooks/dispatch.py
+++ b/providers/webhooks/dispatch.py
@@ -170,6 +170,8 @@ def _route_cfg(cfg: dict[str, Any], provider: str, provider_instance: str, sink:
     watch["route_effective_profile_id"] = effective_profile_id
     if sink in {"crosswatch", "simkl"}:
         watch["route_options"] = {"watch": {"anime_mapping": _anime_mapping_enabled(wh, sink)}}
+    if sink == "simkl":
+        watch["route_options"]["watch"]["simkl_rewatches"] = wh.get("simkl_rewatches") is True
     if provider == "plex":
         watch["filters"] = dict(wh.get("filters_plex") or {})
     elif provider == "emby":

--- a/tests/scrobbler-sink-instances.test.mjs
+++ b/tests/scrobbler-sink-instances.test.mjs
@@ -67,3 +67,28 @@ test("webhook filters instances rather than excluding the whole source provider"
   assert.deepEqual(run('sinkProfiles("plex").map(p => p.instance)'), ["default"]);
   assert.equal(run('selectedSinkInstance("plex")'), "default");
 });
+
+test("watcher rewatch option defaults off, renders only for SIMKL and saves the selection", () => {
+  const run = modal("route");
+  run('props = {}; draft = {provider: "plex", sink: "simkl", options: {watch: {}, scrobble: {}}}; null');
+  let html = run('optionsPanel(draft)');
+  assert.match(html, /Track rewatches/);
+  assert.doesNotMatch(html, /id="scr-simkl-rewatches" checked/);
+  run('draft.options.watch.simkl_rewatches = true; null');
+  assert.match(run('optionsPanel(draft)'), /id="scr-simkl-rewatches" checked/);
+  run('root = {querySelector: (id) => id === "#scr-simkl-rewatches" ? {checked: true} : null, querySelectorAll: () => []}; null');
+  assert.equal(run('collect().options.watch.simkl_rewatches'), true);
+  run('draft.sink = "trakt"; null');
+  assert.doesNotMatch(run('optionsPanel(draft)'), /Track rewatches/);
+  assert.equal(run('Object.hasOwn(collect().options.watch, "simkl_rewatches")'), false);
+});
+
+test("webhook rewatch option defaults off and round trips the destination setting", () => {
+  const run = modal("webhook");
+  run('props = {mode: "edit", overview: {destination_availability: [{provider: "simkl", profiles: [{instance: "default", configured: true}]}]}, webhook: {provider: "plex", provider_instance: "default", sink: "simkl", effective_settings: {sinks: ["simkl"]}}}; null');
+  assert.doesNotMatch(run('optionsPanel()'), /id="scw-simkl-rewatches" checked/);
+  run('props.webhook.effective_settings.simkl_rewatches = true; null');
+  assert.match(run('optionsPanel()'), /id="scw-simkl-rewatches" checked/);
+  run('root = {querySelector: (id) => id === "#scw-sink" ? {value: "simkl"} : id === "#scw-simkl-rewatches" ? {checked: true} : null}; null');
+  assert.equal(run('payload().simkl_rewatches'), true);
+});

--- a/tests/test_simkl_scrobble_rewatches.py
+++ b/tests/test_simkl_scrobble_rewatches.py
@@ -1,0 +1,459 @@
+from __future__ import annotations
+
+import copy
+import json
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
+
+import pytest
+import requests
+
+from cw_platform.local_db.db import close_conn
+from providers.scrobble.scrobble import ScrobbleEvent
+from providers.scrobble.simkl import rewatches, sink
+
+
+def config(enabled=True, token="test-account-a"):
+    return {
+        "simkl": {"api_key": "test-client", "access_token": token},
+        "scrobble": {
+            "trakt": {"watched_at": 90},
+            "watch": {"route_provider": "plex", "route_provider_instance": "P01",
+                      "route_options": {"watch": {"simkl_rewatches": enabled}}},
+        },
+    }
+
+
+def event(action="stop", progress=95, session="session-a"):
+    return ScrobbleEvent(action=action, media_type="movie", ids={"simkl": "123"}, title="Test movie",
+                         year=2020, season=None, number=None, progress=progress, account="test-user",
+                         server_uuid="test-server", session_key=session, raw={})
+
+
+class Response:
+    def __init__(self, payload, status=201):
+        self.payload = payload
+        self.status_code = status
+        self.headers = {}
+        self.text = ""
+
+    def json(self):
+        return self.payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError()
+
+
+@pytest.fixture
+def api(monkeypatch, tmp_path):
+    monkeypatch.setenv("CROSSWATCH_DB", str(tmp_path / "test.sqlite3"))
+    rewatches._PLANS.clear()
+    state = {"plan": "pro", "status": "completed", "http": 201, "calls": [], "records": [], "removed": [], "logs": [], "original_log": sink._log}
+
+    def post(url, **kwargs):
+        state["calls"].append((url, kwargs))
+        if url.endswith("/users/settings"):
+            if state.get("settings_failure"):
+                raise requests.Timeout()
+            account = kwargs["headers"]["Authorization"]
+            return Response({"account": {"type": state["plan"], "id": account}}, 200)
+        if state.get("failure"):
+            raise requests.Timeout()
+        action = "scrobble" if url.endswith("/stop") else url.rsplit("/", 1)[-1]
+        payload = {"action": state.get("action", action), "rewatch_id": 12345}
+        if "allow_rewatch" in kwargs["params"]:
+            payload["rewatch_status"] = state["status"]
+        return Response(payload, state["http"])
+
+    monkeypatch.setattr(sink.requests, "post", post)
+    monkeypatch.setattr(sink, "record_scrobble_event", lambda *a, **k: state["records"].append(k))
+    monkeypatch.setattr(sink, "_auto_remove_across", lambda *a, **k: state["removed"].append(k))
+    monkeypatch.setattr(sink, "record_watch", lambda *a, **k: None)
+    monkeypatch.setattr(sink, "_log", lambda message, level="INFO": state["logs"].append((message, level)))
+    yield state
+    close_conn()
+    rewatches._PLANS.clear()
+
+
+def scrobbles(api):
+    return [(url, kw) for url, kw in api["calls"] if "/scrobble/" in url]
+
+
+def test_default_off_has_no_plan_request_or_rewatch_flag(api):
+    sink.SimklSink().send(event(), config(False))
+    assert len(api["calls"]) == 1
+    assert "allow_rewatch" not in scrobbles(api)[0][1]["params"]
+    assert len(api["records"]) == 1
+
+
+@pytest.mark.parametrize("plan,flag", [("pro", True), ("vip", True), ("free", False)])
+def test_account_plan_gate(api, plan, flag):
+    api["plan"] = plan
+    sink.SimklSink().send(event(), config())
+    assert (scrobbles(api)[0][1]["params"].get("allow_rewatch") == "yes") is flag
+    assert "allow_rewatch" not in scrobbles(api)[0][1]["json"]
+
+
+def test_start_pause_stop_lifecycle_and_no_seek_posts(api):
+    target = sink.SimklSink()
+    target.send(event("start", 10), config())
+    target.send(replace(event("start", 45), raw={"_cw_seek": True}), config())
+    target.send(event("pause", 55), config())
+    target.send(event("start", 60), config())
+    target.send(event("stop", 95), config())
+    calls = scrobbles(api)
+    assert [url.rsplit("/", 1)[-1] for url, _ in calls] == ["start", "pause", "start", "stop"]
+    assert [kw["params"].get("allow_rewatch") for _, kw in calls] == [None, None, None, "yes"]
+
+
+@pytest.mark.parametrize("threshold,progress,flag", [(90, 89, False), (90, 90, True), (70, 79, False), (70, 80, True), (95, 94, False), (95, 95, True)])
+def test_user_threshold_and_simkl_floor(api, threshold, progress, flag):
+    cfg = config()
+    cfg["scrobble"]["trakt"]["watched_at"] = threshold
+    sink.SimklSink().send(event(progress=progress), cfg)
+    assert (scrobbles(api)[0][1]["params"].get("allow_rewatch") == "yes") is flag
+    assert len(api["records"]) == int(flag)
+
+
+@pytest.mark.parametrize("status,saved", [("active", True), ("completed", True), ("closed", True), ("first_watch", True), ("too_soon", False), ("not_eligible", False), ("pro_required", False), (None, False), ("future_status", False)])
+def test_status_controls_completion_even_with_rewatch_id(api, status, saved):
+    api["status"] = status
+    result = sink.SimklSink().send(event(), config())
+    assert len(api["records"]) == int(saved)
+    assert len(api["removed"]) == int(saved)
+    if not saved:
+        assert result["skipped"] is True
+    sink.SimklSink().send(event(), config())
+    assert len(scrobbles(api)) == 1
+
+
+def test_pause_response_is_not_a_completed_watch(api):
+    api["action"] = "pause"
+    result = sink.SimklSink().send(event(), config())
+    assert result["skipped"] is True
+    assert not api["records"]
+
+
+def test_downgrade_stops_flag_on_next_session(api):
+    api["status"] = "pro_required"
+    sink.SimklSink().send(event(), config())
+    sink.SimklSink().send(event(session="session-b"), config())
+    assert [kw["params"].get("allow_rewatch") for _, kw in scrobbles(api)] == ["yes", None]
+    assert len([url for url, _ in api["calls"] if url.endswith("/users/settings")]) == 1
+
+
+def test_duplicate_survives_sink_and_database_restart(api):
+    sink.SimklSink().send(event(), config())
+    close_conn()
+    rewatches._PLANS.clear()
+    result = sink.SimklSink().send(event(), config())
+    assert result["reason"] == "completion_already_processed"
+    assert len(scrobbles(api)) == 1
+
+
+def test_uncertain_delivery_is_not_retried_or_reported_saved(api):
+    api["failure"] = True
+    result = sink.SimklSink().send(event(), config())
+    assert result["retryable"] is False
+    api["failure"] = False
+    result = sink.SimklSink().send(event(), config())
+    assert result["error"] == "rewatch_delivery_unconfirmed"
+    assert len(scrobbles(api)) == 1
+    assert not api["records"]
+
+
+@pytest.mark.parametrize("status", [400, 401, 403, 404, 423, 429])
+def test_definite_rejection_allows_later_event_without_retry_loop(api, status):
+    api["http"] = status
+    result = sink.SimklSink().send(event(), config())
+    assert result["retryable"] is False
+    assert len(scrobbles(api)) == 1
+    api["http"] = 201
+    sink.SimklSink().send(event(), config())
+    assert len(api["records"]) == 1
+
+
+@pytest.mark.parametrize("status", [409, 500])
+def test_duplicate_and_uncertain_server_errors_do_not_repeat(api, status):
+    api["http"] = status
+    sink.SimklSink().send(event(), config())
+    sink.SimklSink().send(event(), config())
+    assert len(scrobbles(api)) == 1
+    assert not api["records"]
+
+
+def test_unknown_plan_waits_and_does_not_send_watch(api):
+    api["settings_failure"] = True
+    result = sink.SimklSink().send(event(), config())
+    assert result["error"] == "simkl_plan_unavailable"
+    assert not scrobbles(api)
+
+
+def test_missing_session_never_opts_into_rewatch(api):
+    sink.SimklSink().send(event(session=None), config())
+    assert "allow_rewatch" not in scrobbles(api)[0][1]["params"]
+
+
+def test_new_sessions_accounts_users_and_profiles_are_independent(api):
+    target = sink.SimklSink()
+    cfg = config()
+    target.send(event(), cfg)
+    target.send(event(session="session-b"), cfg)
+    target.send(event(), config(token="test-account-b"))
+    cfg = copy.deepcopy(cfg)
+    cfg["scrobble"]["watch"]["route_provider_instance"] = "P02"
+    target.send(event(), cfg)
+    target.send(replace(event(), account="other-user"), cfg)
+    assert len(scrobbles(api)) == 5
+
+
+def test_episodes_are_independent_and_server_enforces_gap(api):
+    first = replace(event(), media_type="episode", ids={"tvdb_show": "123"}, season=1, number=1)
+    sink.SimklSink().send(first, config())
+    sink.SimklSink().send(replace(first, number=2), config())
+    api["status"] = "too_soon"
+    result = sink.SimklSink().send(replace(first, session_key="later-session"), config())
+    assert result["reason"] == "too_soon"
+    assert len(api["records"]) == 2
+
+
+def test_atomic_claim_across_workers_and_expiry(api, monkeypatch):
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        results = list(pool.map(lambda _: rewatches.claim("test-key"), range(8)))
+    assert results.count("new") == 1
+    assert results.count("uncertain") == 7
+    now = rewatches.time.time()
+    monkeypatch.setattr(rewatches.time, "time", lambda: now + 49 * 3600)
+    assert rewatches.claim("test-key") == "new"
+
+
+def test_plan_cache_is_account_scoped_and_refreshes(api, monkeypatch):
+    assert rewatches.account(config(), sink._post)[0] == "pro"
+    api["plan"] = "free"
+    assert rewatches.account(config(token="test-account-b"), sink._post)[0] == "free"
+    assert rewatches.account(config(), sink._post)[0] == "pro"
+    now = rewatches.time.time()
+    monkeypatch.setattr(rewatches.time, "time", lambda: now + 301)
+    assert rewatches.account(config(), sink._post)[0] == "free"
+
+
+def test_persistent_store_failure_prevents_opt_in(api, monkeypatch):
+    monkeypatch.setattr(rewatches, "get_conn", lambda: None)
+    result = sink.SimklSink().send(event(), config())
+    assert result["error"] == "rewatch_dedupe_unavailable"
+    assert not scrobbles(api)
+
+
+def test_request_boundary_never_flags_start_or_pause(api):
+    for path in ("/scrobble/start", "/scrobble/pause", "/users/settings"):
+        sink._post(path, {"progress": 99}, config(), allow_rewatch=True)
+    assert all("allow_rewatch" not in kw["params"] for _, kw in api["calls"])
+
+
+def test_watcher_and_webhook_use_same_completion_guard(api):
+    from providers.scrobble.routes import build_route_cfg
+    from providers.webhooks.dispatch import _route_cfg
+
+    cfg = config()
+    cfg["scrobble"]["webhook"] = {"simkl_rewatches": True, "sinks": ["simkl"]}
+    route = {"id": "R1", "provider": "plex", "provider_instance": "P01", "sink": "simkl",
+             "sink_instance": "default", "enabled": True, "options": {"watch": {"simkl_rewatches": True}}}
+    watcher = build_route_cfg(cfg, route)
+    webhook = _route_cfg(cfg, "plex", "P01", "simkl", "default")
+    assert rewatches.enabled(watcher)
+    assert rewatches.enabled(webhook)
+    sink.SimklSink().send(event(), watcher)
+    result = sink.SimklSink().send(event(), webhook)
+    assert result["skipped"] is True
+    assert len(scrobbles(api)) == 1
+
+
+def test_webhook_option_is_normalized_and_scoped(api):
+    from api.scrobblerManagementAPI import _normalize_webhook_settings
+    from providers.webhooks.dispatch import _route_cfg
+
+    cfg = config()
+    settings = _normalize_webhook_settings(cfg, "plex", {"sinks": ["simkl"], "simkl_rewatches": True})
+    cfg["scrobble"]["webhook"] = {"profiles": {"plex": {"P01": settings}}}
+    assert rewatches.enabled(_route_cfg(cfg, "plex", "P01", "simkl", "default"))
+    assert not rewatches.enabled(_route_cfg(cfg, "plex", "P02", "simkl", "default"))
+
+
+@pytest.mark.parametrize("plan,allowed", [("pro", True), ("vip", True), ("free", False)])
+def test_enable_validation_uses_destination_plan(api, plan, allowed):
+    from api.scrobblerManagementAPI import ValidationFailure, _require_simkl_rewatches
+
+    api["plan"] = plan
+    if allowed:
+        _require_simkl_rewatches(config(), "default", "simkl_rewatches")
+    else:
+        with pytest.raises(ValidationFailure):
+            _require_simkl_rewatches(config(), "default", "simkl_rewatches")
+
+
+@pytest.mark.parametrize("provider", ["plex", "jellyfin", "emby"])
+def test_real_webhook_dispatch_preserves_rewatch_outcome(api, monkeypatch, provider):
+    from providers.webhooks import dispatch
+
+    monkeypatch.setattr(dispatch, "_SINKS", {})
+    cfg = config()
+    cfg["scrobble"]["webhook"] = {"sinks": ["simkl"], "simkl_rewatches": True}
+    api["status"] = "too_soon"
+    result = dispatch.dispatch_scrobble(provider, "/scrobble/stop", media_type="movie", ids={"simkl": "123"},
+                                       progress=95, session_key="webhook-session", account="test-user", cfg=cfg)
+    assert result.status_code == 200
+    assert result.json()["targets"][0]["reason"] == "too_soon"
+    assert result.json()["activity_recorded"] is False
+    assert scrobbles(api)[0][1]["params"]["allow_rewatch"] == "yes"
+
+
+def test_current_progress_cannot_be_raised_over_rewatch_threshold(api):
+    target = sink.SimklSink()
+    target.send(event("start", 92), config())
+    target.send(event("stop", 89), config())
+    assert scrobbles(api)[-1][0].endswith("/pause")
+    assert not api["records"]
+
+
+def test_watcher_opt_in_requires_boolean_true(api):
+    from providers.scrobble.routes import normalize_route_options
+
+    options = normalize_route_options({"watch": {"simkl_rewatches": "false"}})
+    assert options["watch"]["simkl_rewatches"] is False
+
+
+def diagnostics(api, kind):
+    prefix = f"rewatch.{kind} "
+    return [json.loads(message[len(prefix):]) for message, level in api["logs"] if level == "DEBUG" and message.startswith(prefix)]
+
+
+def test_diagnostics_correlate_route_profiles_session_and_results(api):
+    cfg = config()
+    cfg["scrobble"]["watch"].update(route_id="R12", route_effective_profile_id="profile-a")
+    sink.SimklSink(instance_id="S02").send(event(), cfg)
+    result = diagnostics(api, "result")[0]
+    assert result["route"] == "R12"
+    assert result["source"] == "plex"
+    assert result["source_instance"] == "P01"
+    assert result["destination_instance"] == "S02"
+    assert result["profile"] == "profile-a"
+    assert result["user"] == "te***"
+    assert len(result["session_ref"]) == 12
+    assert result["session_ref"] != "session-a"
+    assert result["saved"] is True
+    assert result["rewatch_status"] == "completed"
+    for kind in ("plan", "dedupe", "request", "response", "eligibility"):
+        assert diagnostics(api, kind)[0]["session_ref"] == result["session_ref"]
+    assert diagnostics(api, "request")[0]["allow_rewatch"] is True
+    assert diagnostics(api, "response")[0]["http_status"] == 201
+    assert diagnostics(api, "response")[0]["elapsed_ms"] >= 0
+
+
+def test_diagnostics_show_persistent_duplicate_and_cached_plan(api):
+    sink.SimklSink().send(event(), config())
+    sink.SimklSink().send(event(), config())
+    assert [row["decision"] for row in diagnostics(api, "dedupe")] == ["new", "finished", "done"]
+    assert [row["cache"] for row in diagnostics(api, "plan")] == ["miss", "hit"]
+    assert diagnostics(api, "plan")[-1]["expires_in_s"] > 0
+
+
+@pytest.mark.parametrize("failure,cause", [(requests.Timeout, "timeout"), (requests.ConnectionError, "connection_error"), (RuntimeError, "request_error")])
+def test_transport_diagnostics_never_log_exception_credentials(api, monkeypatch, failure, cause):
+    cfg = config()
+    rewatches.account(cfg, sink._post)
+
+    def fail(*args, **kwargs):
+        raise failure("Authorization: Bearer test-account-a; api_key=test-client; private-server")
+
+    monkeypatch.setattr(sink.requests, "post", fail)
+    target = sink.SimklSink()
+    target.send(event(), cfg)
+    target.send(event(), cfg)
+    assert diagnostics(api, "response")[0]["outcome"] == cause
+    assert diagnostics(api, "failure")[0]["retryable"] is False
+    assert diagnostics(api, "dedupe")[-1]["decision"] == "uncertain"
+    messages = "\n".join(message for message, _ in api["logs"])
+    for secret in ("test-account-a", "test-client", "private-server", "Authorization", "session-a"):
+        assert secret not in messages
+
+
+@pytest.mark.parametrize("case,cause,status", [("timeout", "timeout", 0), ("connection", "connection_error", 0), ("http", "http_error", 401), ("invalid", "invalid_response", 200), ("plan", "invalid_plan", 200)])
+def test_plan_failure_diagnostics_survive_cache_hit(api, monkeypatch, case, cause, status):
+    def post(*args, **kwargs):
+        if case == "timeout":
+            raise requests.Timeout("secret")
+        if case == "connection":
+            raise requests.ConnectionError("secret")
+        return Response({"account": {"type": "unexpected"}} if case == "plan" else {}, status)
+
+    monkeypatch.setattr(sink.requests, "post", post)
+    sink.SimklSink().send(event(), config())
+    sink.SimklSink().send(event(), config())
+    rows = diagnostics(api, "plan")
+    assert [row["cache"] for row in rows] == ["miss", "hit"]
+    assert all(row["reason"] == cause and row["http_status"] == status for row in rows)
+    assert diagnostics(api, "skip")[0]["reason"] == "simkl_plan_unavailable"
+
+
+@pytest.mark.parametrize("payload,status,outcome", [({}, 201, "invalid_response"), ("private error page", 201, "invalid_response"), ({"error": "RATE_LIMIT"}, 400, "http_error")])
+def test_response_diagnostics_distinguish_malformed_and_rate_limited(api, monkeypatch, payload, status, outcome):
+    cfg = config()
+    rewatches.account(cfg, sink._post)
+    monkeypatch.setattr(sink.requests, "post", lambda *a, **k: Response(payload, status))
+    sink.SimklSink().send(event(), cfg)
+    row = diagnostics(api, "response")[0]
+    assert row["outcome"] == outcome
+    assert row["http_status"] == status
+    assert row["api_error"] == ("RATE_LIMIT" if status == 400 else None)
+    assert "private error page" not in str(api["logs"])
+    assert not api["records"]
+
+
+def test_diagnostics_show_threshold_missing_session_and_downgrade(api):
+    sink.SimklSink().send(event(progress=79), config())
+    assert diagnostics(api, "threshold")[0]["action"] == "pause"
+    assert diagnostics(api, "threshold")[0]["watched_at"] == 90
+    sink.SimklSink().send(event(session=None), config())
+    assert diagnostics(api, "eligibility")[-1]["reason"] == "missing_session"
+    api["status"] = "pro_required"
+    sink.SimklSink().send(event(), config())
+    assert diagnostics(api, "plan")[-1]["reason"] == "pro_required"
+    assert diagnostics(api, "plan")[-1]["plan"] == "free"
+
+
+def test_diagnostics_record_storage_failures(api, monkeypatch):
+    monkeypatch.setattr(rewatches, "get_conn", lambda: None)
+    sink.SimklSink().send(event(), config())
+    assert diagnostics(api, "dedupe")[0]["decision"] == "storage_error"
+
+
+def test_webhook_diagnostics_show_skip_without_watcher_dispatcher(api, monkeypatch):
+    from providers.webhooks import dispatch
+
+    monkeypatch.setattr(dispatch, "_SINKS", {})
+    cfg = config()
+    cfg["scrobble"]["webhook"] = {"sinks": ["simkl"], "simkl_rewatches": True}
+    api["status"] = "too_soon"
+    for _ in range(2):
+        dispatch.dispatch_scrobble("jellyfin", "/scrobble/stop", media_type="movie", ids={"simkl": "123"},
+                                   progress=95, session_key="webhook-session", account="test-user", cfg=cfg)
+    result = diagnostics(api, "result")[0]
+    assert result["route"] == "webhook:jellyfin:default:simkl:default"
+    assert result["method"] == "webhook"
+    assert result["rewatch_status"] == "too_soon"
+    assert result["saved"] is False
+    assert diagnostics(api, "dedupe")[-1]["decision"] == "done"
+
+
+def test_new_diagnostics_obey_debug_setting(api, monkeypatch):
+    output = []
+    monkeypatch.setattr(sink, "_log", api["original_log"])
+    monkeypatch.setattr(sink, "BASE_LOG", lambda message, **kwargs: output.append(message))
+    monkeypatch.setattr(sink, "_is_debug", lambda: False)
+    target = sink.SimklSink()
+    target._rewatch_log(event(), config(), "skip", reason="test")
+    assert not output
+    monkeypatch.setattr(sink, "_is_debug", lambda: True)
+    target._rewatch_log(event(), config(), "skip", reason="test")
+    assert len(output) == 1


### PR DESCRIPTION
# Pull request

## Change

- Add a default-off Track rewatches option for SIMKL watcher routes and webhook destinations
- With duplicate protection and debug logs.

## Why

- Allow Pro and VIP users to record rewatches while respecting watched thresholds and the 48-hour rule. 
- Send the rewatch flag only on qualifying stops.

## Testing
-  tests/test_simkl_scrobble_rewatches.py

## Issue
Relates to #1097