### PR TITLE
Add: configurable history timestamp tolerance

### DIFF
--- a/cw_platform/config_base.py
+++ b/cw_platform/config_base.py
@@ -728,6 +728,7 @@ DEFAULT_CFG: dict[str, Any] = {
         "state_dir": "",                                # Optional override for state dir (defaults to CONFIG/state)  - this will break container setups!
         "telemetry": {"enabled": True},                 # Usage stats
         "max_profiles_per_provider": 10,                # Total profiles per provider incl. default (1-100)
+        "history_timestamp_tolerance_seconds": 60,      # Same-viewing history match window; 0 requires exact timestamps
 
         # progress
         "snapshot_ttl_sec": 300,                        # Reuse snapshots within 5 min

--- a/cw_platform/orchestrator/_history_rewatches.py
+++ b/cw_platform/orchestrator/_history_rewatches.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2025-2026 CrossWatch / Cenodude (https://github.com/cenodude/CrossWatch)
 from __future__ import annotations
 
+from bisect import bisect_left, bisect_right
 from collections.abc import Callable, Mapping
 from typing import Any
 
@@ -12,8 +13,25 @@ from ..history_events import (
     history_epoch_from_key,
     history_event_key,
     history_sync_key,
+    is_history_event_key,
     minimal_history_item,
 )
+
+HISTORY_TIMESTAMP_TOLERANCE_SECONDS = 60
+
+
+def history_timestamp_tolerance_seconds(config: Mapping[str, Any]) -> int:
+    """Read the shared runtime window; malformed values use the default."""
+    runtime = config.get("runtime")
+    value = HISTORY_TIMESTAMP_TOLERANCE_SECONDS
+    if isinstance(runtime, Mapping):
+        value = runtime.get("history_timestamp_tolerance_seconds", value)
+    if isinstance(value, bool):
+        return HISTORY_TIMESTAMP_TOLERANCE_SECONDS
+    try:
+        return max(0, int(str(value).strip()))
+    except (TypeError, ValueError):
+        return HISTORY_TIMESTAMP_TOLERANCE_SECONDS
 
 
 def history_rewatches_requested(feature: str, fcfg: Mapping[str, Any]) -> bool:
@@ -112,33 +130,117 @@ def filter_history_events(idx: Mapping[str, Any], *, event_mode: bool) -> dict[s
     return out
 
 
-def history_event_present(
-    item: Mapping[str, Any],
-    fallback_key: Any,
-    other_idx: Mapping[str, Any],
+def history_event_matches(
+    src_idx: Mapping[str, Any],
+    dst_idx: Mapping[str, Any],
     typed_tokens: Callable[[Mapping[str, Any]], set[str]],
-    bucket_sec: int,
-) -> bool:
-    key = history_event_key(item, fallback_key)
-    if key and key in other_idx:
-        return True
-    ts = history_epoch_from_item(item) or history_epoch_from_key(key)
-    if ts is None:
-        return False
-    b = max(0, int(bucket_sec or 0))
-    ts_cmp = ts if b <= 1 else (ts // b) * b
-    for other_key, other_item in (other_idx or {}).items():
-        if not isinstance(other_item, Mapping):
-            continue
-        other_ts = history_epoch_from_item(other_item) or history_epoch_from_key(other_key)
-        if other_ts is None:
-            continue
-        other_cmp = other_ts if b <= 1 else (other_ts // b) * b
-        if other_cmp != ts_cmp:
-            continue
-        if typed_tokens(item) & typed_tokens(other_item):
-            return True
-    return False
+    *,
+    tolerance_seconds: int = HISTORY_TIMESTAMP_TOLERANCE_SECONDS,
+) -> dict[str, str]:
+    """Pair viewings without changing timestamps or reusing a destination row.
+
+    Prefer exact event identities, then the unique nearest timestamp on both
+    sides. Equally close alternatives remain unmatched. Index by identity and
+    time so unrelated library rows never require a pairwise comparison.
+    """
+    tolerance = max(0, int(tolerance_seconds))
+
+    def records(idx: Mapping[str, Any]) -> dict[str, tuple[int, str, set[str]]]:
+        out = {}
+        for key, item in idx.items():
+            if not isinstance(item, Mapping):
+                continue
+            epoch = history_epoch_from_item(item)
+            if epoch is None:
+                epoch = history_epoch_from_key(key)
+            if epoch is None:
+                continue
+            typ = str(item.get("type") or "").strip().lower()
+            typ = "show" if typ == "tv" else typ
+            event_key = history_event_key(item, key)
+            tokens = {f"{typ}|{token}" for token in typed_tokens(item)}
+            out[key] = (epoch, event_key, tokens)
+        return out
+
+    sources, targets = records(src_idx), records(dst_idx)
+    sparse_events = {event_key for _, event_key, tokens in (*sources.values(), *targets.values())
+                     if not tokens and is_history_event_key(event_key)}
+    for idx, rows in ((src_idx, sources), (dst_idx, targets)):
+        for key, (_, event_key, tokens) in rows.items():
+            if event_key in sparse_events:
+                # Only sparse records fall back to exact event identity.
+                # Explicit provider mappings remain authoritative.
+                typ = str(idx[key].get("type") or "").strip().lower()
+                typ = "show" if typ == "tv" else typ
+                tokens.add(f"{typ}|event:{event_key}")
+    postings: dict[str, list[tuple[int, str]]] = {}
+    for key, (epoch, _, tokens) in targets.items():
+        for token in tokens:
+            postings.setdefault(token, []).append((epoch, key))
+    for rows in postings.values():
+        rows.sort()
+
+    candidates: dict[str, dict[str, tuple[int, int]]] = {}
+    reverse: dict[str, dict[str, tuple[int, int]]] = {}
+    for key, (epoch, event_key, tokens) in sources.items():
+        peers = {}
+        for token in tokens:
+            rows = postings.get(token, [])
+            lo = bisect_left(rows, epoch - tolerance, key=lambda row: row[0])
+            hi = bisect_right(rows, epoch + tolerance, key=lambda row: row[0])
+            for other_epoch, other_key in rows[lo:hi]:
+                score = (int(event_key != targets[other_key][1]), abs(epoch - other_epoch))
+                peers[other_key] = score
+        if peers:
+            candidates[key] = peers
+            for other_key, score in peers.items():
+                reverse.setdefault(other_key, {})[key] = score
+
+    def nearest(peers: Mapping[str, tuple[int, int]]) -> str | None:
+        if not peers:
+            return None
+        score = min(peers.values())
+        best = [key for key, value in peers.items() if value == score]
+        return best[0] if len(best) == 1 else None
+
+    matches: dict[str, str] = {}
+    while candidates:
+        source_choices = {key: nearest(peers) for key, peers in candidates.items()}
+        target_choices = {key: nearest(peers) for key, peers in reverse.items()}
+        pairs = [(key, peer) for key, peer in source_choices.items()
+                 if peer is not None and target_choices.get(peer) == key]
+        if not pairs:
+            break
+        for key, peer in pairs:
+            matches[key] = peer
+            for other_key in candidates.pop(key):
+                reverse[other_key].pop(key, None)
+            for source_key in reverse.pop(peer):
+                candidates[source_key].pop(peer, None)
+        candidates = {key: peers for key, peers in candidates.items() if peers}
+        reverse = {key: peers for key, peers in reverse.items() if peers}
+    return matches
+
+
+def compare_history_events(
+    src_idx: Mapping[str, Any],
+    dst_idx: Mapping[str, Any],
+    typed_tokens: Callable[[Mapping[str, Any]], set[str]],
+    *,
+    tolerance_seconds: int = HISTORY_TIMESTAMP_TOLERANCE_SECONDS,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], dict[str, str]]:
+    """Return missing viewings and the matched original source/target keys."""
+    adds: list[dict[str, Any]] = []
+    removes: list[dict[str, Any]] = []
+    matches = history_event_matches(src_idx, dst_idx, typed_tokens, tolerance_seconds=tolerance_seconds)
+    matched_targets = set(matches.values())
+    for key, value in (src_idx or {}).items():
+        if isinstance(value, Mapping) and key not in matches:
+            adds.append(minimal_history_item(value, key, event_mode=True))
+    for key, value in (dst_idx or {}).items():
+        if isinstance(value, Mapping) and key not in matched_targets:
+            removes.append(minimal_history_item(value, key, event_mode=True))
+    return adds, removes, matches
 
 
 def history_event_diff(
@@ -146,14 +248,9 @@ def history_event_diff(
     dst_idx: Mapping[str, Any],
     typed_tokens: Callable[[Mapping[str, Any]], set[str]],
     *,
-    bucket_sec: int = 0,
+    tolerance_seconds: int = HISTORY_TIMESTAMP_TOLERANCE_SECONDS,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-    adds: list[dict[str, Any]] = []
-    removes: list[dict[str, Any]] = []
-    for key, value in (src_idx or {}).items():
-        if isinstance(value, Mapping) and not history_event_present(value, key, dst_idx, typed_tokens, bucket_sec):
-            adds.append(minimal_history_item(value, key, event_mode=True))
-    for key, value in (dst_idx or {}).items():
-        if isinstance(value, Mapping) and not history_event_present(value, key, src_idx, typed_tokens, bucket_sec):
-            removes.append(minimal_history_item(value, key, event_mode=True))
+    adds, removes, _ = compare_history_events(
+        src_idx, dst_idx, typed_tokens, tolerance_seconds=tolerance_seconds,
+    )
     return adds, removes

--- a/cw_platform/orchestrator/_pairs_oneway.py
+++ b/cw_platform/orchestrator/_pairs_oneway.py
@@ -179,11 +179,6 @@ def compute_effective_remove(
     }
 
 
-def is_remove_retry_reason(reason) -> bool:
-    r = str(reason or "").strip().lower()
-    return r.startswith("apply:remove") or r.startswith("two:apply:remove") or r.startswith("provider_down:remove")
-
-
 def resolve_baseline_writes(baseline_keys, key2item, result) -> list:
     dest_map = (result or {}).get("confirmed_destinations")
     dest_map = dest_map if isinstance(dest_map, Mapping) else {}
@@ -238,7 +233,7 @@ from ._snapshots import (
 )
 from ._applier import apply_add, apply_remove, apply_update
 from ._chunking import effective_chunk_size
-from ._unresolved import load_unresolved_keys, load_unresolved_map, load_unresolved_pending, record_unresolved, clear_unresolved
+from ._unresolved import load_unresolved_keys, load_unresolved_map, load_unresolved_pending, record_unresolved, clear_unresolved, clear_matched_history_retries, is_remove_retry_reason
 from ._planner import diff, diff_ratings, diff_progress, _pick_rating
 from ._phantoms import PhantomGuard
 from ._tombstones import clear_items_for_feature
@@ -262,8 +257,9 @@ from ._history_rewatches import (
     collapse_history_latest,
     config_with_history_rewatches,
     filter_history_events,
-    history_event_diff,
-    history_event_present,
+    compare_history_events,
+    history_event_matches,
+    history_timestamp_tolerance_seconds,
     history_rewatch_pair_enabled,
     history_rewatches_requested,
 )
@@ -770,6 +766,7 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
     health_map: Mapping[str, Any],
 ) -> dict[str, Any]:
     cfg, emit, dbg = ctx.config, ctx.emit, ctx.dbg
+    history_tolerance = history_timestamp_tolerance_seconds(cfg)
     src_inst = normalize_instance_id(os.getenv("CW_PAIR_SRC_INSTANCE"))
     dst_inst = normalize_instance_id(os.getenv("CW_PAIR_DST_INSTANCE"))
     sync_cfg = (cfg.get("sync") or {})
@@ -960,11 +957,8 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
         direct = idx.get(sk) if sk else None
         if isinstance(direct, Mapping):
             return direct
-        bucket_sec = _history_bucket_sec(src, dst, feature)
-        for dk, dv in (idx or {}).items():
-            if isinstance(dv, Mapping) and history_event_present(it, sk, {str(dk): dv}, _typed_tokens, bucket_sec=bucket_sec):
-                return dv
-        return None
+        matches = history_event_matches({sk: it}, idx, _typed_tokens, tolerance_seconds=history_tolerance)
+        return idx.get(matches[sk]) if sk in matches else None
 
     def _show_level_tokens(it: Mapping[str, Any]) -> set[str]:
         ids_raw = it.get("show_ids") if isinstance(it.get("show_ids"), Mapping) else it.get("ids")
@@ -1308,6 +1302,7 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
         remove_mode = "source_deletes"
 
     mirror_removes: list[dict[str, Any]] = []
+    matched_history_keys: set[str] = set()
     updates: list[dict[str, Any]] = []
     if feature == "ratings":
         src_idx  = _ratings_filter_index(src_idx,  fcfg)
@@ -1374,12 +1369,13 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
         if feature == "history" and history_event_mode:
             src_idx = filter_history_events(src_idx, event_mode=True)
             dst_full = filter_history_events(dst_full, event_mode=True)
-            adds, mirror_removes = history_event_diff(
+            adds, mirror_removes, history_matches = compare_history_events(
                 src_idx,
                 dst_full,
                 typed_tokens=_typed_tokens,
-                bucket_sec=_history_bucket_sec(src, dst, feature),
+                tolerance_seconds=history_tolerance,
             )
+            matched_history_keys = set(history_matches)
         elif feature == "history" and not history_event_mode:
             src_idx = {
                 k: dict(v) for k, v in src_idx.items()
@@ -1758,6 +1754,12 @@ def run_one_way_feature(  # pyright: ignore[reportGeneralTypeIssues]
     verify_after_write = bool(sync_cfg.get("verify_after_write", False))
     post_apply_add_res: dict[str, Any] | None = None
     cancelled = cancelled or bool(cancel_requested())
+
+    if matched_history_keys and not (cancelled or dry_run_flag or src_down or dst_down or src_suspect or dst_suspect):
+        resolved = clear_matched_history_retries(dst, matched_history_keys)
+        if resolved:
+            resolved_items = {key: src_idx[event_key] for key, event_key in resolved.items()}
+            _emit_item_resolutions(emit, dst, feature, pair_key, resolved, resolved_items)
 
     if updates and not cancelled:
         if dst_down:

--- a/cw_platform/orchestrator/_pairs_twoway.py
+++ b/cw_platform/orchestrator/_pairs_twoway.py
@@ -103,7 +103,7 @@ from ._snapshots import (
 from ._applier import apply_add, apply_remove, apply_update
 from ._chunking import effective_chunk_size
 from ._tombstones import clear_items_for_feature, keys_for_feature
-from ._unresolved import load_unresolved_keys, load_unresolved_pending, record_unresolved, clear_unresolved
+from ._unresolved import load_unresolved_keys, load_unresolved_pending, record_unresolved, clear_unresolved, clear_matched_history_retries
 from ._phantoms import PhantomGuard  # type: ignore[attr-defined]
 
 from ._pairs_blocklist import apply_blocklist
@@ -112,8 +112,9 @@ from ._history_rewatches import (
     collapse_history_latest,
     config_with_history_rewatches,
     filter_history_events,
-    history_event_diff,
-    history_event_present,
+    compare_history_events,
+    history_event_matches,
+    history_timestamp_tolerance_seconds,
     history_rewatch_pair_enabled,
     history_rewatches_requested,
 )
@@ -354,6 +355,7 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
     import time as _t
 
     cfg, emit, info, dbg = ctx.config, ctx.emit, ctx.emit_info, ctx.dbg
+    history_tolerance = history_timestamp_tolerance_seconds(cfg)
     src_inst = normalize_instance_id(os.getenv("CW_PAIR_SRC_INSTANCE"))
     dst_inst = normalize_instance_id(os.getenv("CW_PAIR_DST_INSTANCE"))
     sync_cfg = (cfg.get("sync") or {})
@@ -811,11 +813,8 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
         direct = idx.get(sk) if sk else None
         if isinstance(direct, Mapping):
             return direct
-        bucket_sec = _hist_bucket_sec(a, b, feature)
-        for dk, dv in (idx or {}).items():
-            if isinstance(dv, Mapping) and history_event_present(it, sk, {str(dk): dv}, _typed_tokens, bucket_sec=bucket_sec):
-                return dv
-        return None
+        matches = history_event_matches({sk: it}, idx, _typed_tokens, tolerance_seconds=history_tolerance)
+        return idx.get(matches[sk]) if sk in matches else None
 
     def _show_level_tokens(it: Mapping[str, Any]) -> set[str]:
         ids_raw = it.get("show_ids") if isinstance(it.get("show_ids"), Mapping) else it.get("ids")
@@ -1043,6 +1042,8 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
 
     add_to_A: list[dict[str, Any]] = []
     add_to_B: list[dict[str, Any]] = []
+    matched_history_to_A: set[str] = set()
+    matched_history_to_B: set[str] = set()
     upd_to_A: list[dict[str, Any]] = []
     upd_to_B: list[dict[str, Any]] = []
     rem_from_A: list[dict[str, Any]] = []
@@ -1533,9 +1534,11 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
             B_eff = filter_history_events(B_eff, event_mode=True)
             A_alias = _alias_index(A_eff)
             B_alias = _alias_index(B_eff)
-            bucket_sec = _hist_bucket_sec(a, b, feature)
-            missing_for_B, _ = history_event_diff(A_eff, B_eff, typed_tokens=_typed_tokens, bucket_sec=bucket_sec)
-            missing_for_A, _ = history_event_diff(B_eff, A_eff, typed_tokens=_typed_tokens, bucket_sec=bucket_sec)
+            missing_for_B, missing_for_A, history_matches = compare_history_events(
+                A_eff, B_eff, typed_tokens=_typed_tokens, tolerance_seconds=history_tolerance,
+            )
+            matched_history_to_B = set(history_matches)
+            matched_history_to_A = set(history_matches.values())
 
             for v in missing_for_B:
                 tomb_blocks = _tomb_blocks_remove(v, prev_self=prevA, prev_self_alias=prevA_alias)
@@ -1901,6 +1904,14 @@ def _two_way_sync(  # pyright: ignore[reportGeneralTypeIssues]
          upd_to_A=len(upd_to_A), upd_to_B=len(upd_to_B),
          rem_from_A=len(rem_from_A), rem_from_B=len(rem_from_B))
     cancelled = cancelled or bool(cancel_requested())
+
+    if not (cancelled or dry_run_flag or a_down or b_down or A_suspect or B_suspect):
+        for provider, matched, items in ((a, matched_history_to_A, B_eff), (b, matched_history_to_B, A_eff)):
+            if matched:
+                resolved = clear_matched_history_retries(provider, matched)
+                if resolved:
+                    resolved_items = {key: items[event_key] for key, event_key in resolved.items()}
+                    _emit_item_resolutions(emit, provider, feature, pair_key, resolved, resolved_items)
 
     review = getattr(ctx, "interactive", None)
     if review is not None:

--- a/cw_platform/orchestrator/_unresolved.py
+++ b/cw_platform/orchestrator/_unresolved.py
@@ -10,6 +10,8 @@ import json
 import logging
 import time
 
+from ..history_events import history_epoch_from_item, history_event_key, is_history_event_key
+
 __all__ = [
     "load_unresolved_keys",
     "load_unresolved_map",
@@ -17,6 +19,9 @@ __all__ = [
     "load_unresolved_pending",
     "record_unresolved",
     "clear_unresolved",
+    "clear_matched_history_retries",
+    "is_remove_retry_reason",
+    "is_remove_retry",
 ]
 
 STATE_DIR = Path("/config/.cw_state")
@@ -381,6 +386,64 @@ def record_unresolved(
 
     ok, error = _atomic_write(path, data)
     return {"ok": ok, "count": added if ok else 0, "path": str(path), **({"error": error} if error else {})}
+
+
+def is_remove_retry_reason(reason: Any) -> bool:
+    r = str(reason or "").strip().lower()
+    return r.startswith("apply:remove") or r.startswith("two:apply:remove") or r.startswith("provider_down:remove")
+
+
+def is_remove_retry(record: Mapping[str, Any] | None) -> bool:
+    if not isinstance(record, Mapping):
+        return False
+    if str(record.get("action") or "").strip().lower() == "remove":
+        return True
+    reasons = [record.get(field) for field in ("reason", "hint", "error")]
+    if isinstance(record.get("reasons"), list):
+        reasons.extend(record["reasons"])
+    for reason in reasons:
+        if is_remove_retry_reason(reason):
+            return True
+        # Providers also emit codes such as simkl_remove_not_confirmed and
+        # trakt_history_remove_unconfirmed instead of orchestrator prefixes.
+        if "remove" in str(reason or "").strip().lower().replace(":", "_").split("_"):
+            return True
+    return False
+
+
+def clear_matched_history_retries(dst: str, matched_keys: Iterable[str]) -> dict[str, str]:
+    """Clear add failures already confirmed by a pair's history comparison.
+
+    A present watch does not confirm a pending deletion. Keep those failures,
+    and never broaden an event key into a title-wide retry cleanup.
+    Return retry keys mapped to confirmed event keys so callers can retain
+    the correct item metadata when recording resolutions.
+    """
+    records = load_unresolved_map(dst, "history", cross_features=False)
+    # Pending hints can shadow a provider's blocking row in the merged map.
+    blocking = _read_json(_blocking_path(dst, "history"))
+    matched = set(matched_keys)
+    pending_items = {row["key"]: row.get("item") for row in load_unresolved_pending(dst, "history")}
+    resolved: dict[str, str] = {}
+    for key, record in records.items():
+        if not isinstance(record, Mapping):
+            continue
+        if is_remove_retry(record) or is_remove_retry(blocking.get(key)):
+            continue
+        event_key = str(key)
+        if not is_history_event_key(event_key):
+            # Base-keyed retries retain the watch timestamp in the payload.
+            # Resolve only that specific viewing.
+            item = record.get("item") or pending_items.get(key)
+            if not isinstance(item, Mapping) or history_epoch_from_item(item) is None:
+                continue
+            event_key = history_event_key(item, key)
+        if event_key not in matched:
+            continue
+        resolved[str(key)] = event_key
+    if resolved:
+        clear_unresolved(dst, "history", resolved)
+    return resolved
 
 
 def clear_unresolved(

--- a/services/analyzer.py
+++ b/services/analyzer.py
@@ -30,7 +30,8 @@ from cw_platform.anime_mapping.history_coords import (
 )
 from cw_platform.anime_mapping.storage import index_ready as anime_index_ready
 from cw_platform.config_base import CONFIG as CONFIG_DIR, load_config
-from cw_platform.orchestrator._history_rewatches import history_event_present
+from cw_platform.orchestrator._history_rewatches import history_event_matches, history_timestamp_tolerance_seconds
+from cw_platform.orchestrator._unresolved import is_remove_retry
 from cw_platform.local_db.legacy_files import DB_MANAGED_ARTIFACTS
 from cw_platform.modules_registry import get_sync_module_path_by_name, sync_provider_names
 from cw_platform.provider_instances import normalize_instance_id
@@ -2518,6 +2519,7 @@ class _AnalysisContext:
     history_pair_aliases: dict[tuple[str, str], dict[str, Any]] = field(default_factory=dict)
     history_keys: dict[str, dict[str, Any]] = field(default_factory=dict)
     history_rewatch_pairs: set[tuple[str, str]] = field(default_factory=set)
+    history_matches: dict[tuple[str, str], dict[str, str]] = field(default_factory=dict)
     history_identity_items: dict[str, dict[str, list[tuple[str, Mapping[str, Any]]]]] = field(default_factory=dict)
     anime_coords: _AnimeHistoryCoords | None = None
 
@@ -2547,6 +2549,40 @@ def _analysis_context(s: dict[str, Any], cfg: dict[str, Any] | None = None) -> _
     )
 
 
+def _history_peer_matches(ctx: _AnalysisContext, src: str, dst: str) -> dict[str, str]:
+    pair = (src, dst)
+    if pair in ctx.history_matches:
+        return ctx.history_matches[pair]
+    coords = ctx.anime_coords.pair(src, dst) if ctx.anime_coords else None
+
+    def prepared(provider: str, *, source: bool) -> dict[str, Any]:
+        out = {}
+        for key, item in ctx.history_keys.get(provider, {}).items():
+            if source and (
+                not _passes_pair_lib_filter(ctx.pair_libs, src, "history", dst, item)
+                or not _passes_pair_type_filter(ctx.pair_types, src, "history", dst, item)
+            ):
+                continue
+            alias = _alias_peer_key(ctx, src, dst, key, item) if source else None
+            tokens = _history_event_tokens(item)
+            if coords:
+                tokens |= set(coords.aliases.tokens(item)) | _history_coord_peer_tokens(item)
+            if alias:
+                tokens = {f"pair_alias:{alias}"}
+            elif not source:
+                tokens |= {f"pair_alias:{key}", f"pair_alias:{key.split('@', 1)[0]}"}
+            out[key] = {**item, "_cw_history_match_tokens": tokens}
+        return out
+
+    matches = history_event_matches(
+        prepared(src, source=True), prepared(dst, source=False),
+        lambda item: item["_cw_history_match_tokens"],
+        tolerance_seconds=history_timestamp_tolerance_seconds(ctx.cfg),
+    )
+    ctx.history_matches[pair] = matches
+    return matches
+
+
 def _target_peer_match(
     ctx: _AnalysisContext,
     prov: str,
@@ -2568,15 +2604,11 @@ def _target_peer_match(
     # For history episodes/seasons, exact show+season+episode identity wins over
     # generic alias overlap: provider episode IDs differ across Emby/Jellyfin.
     if feat_key == "history":
+        if (prov_key, dst_key) in ctx.history_rewatch_pairs:
+            return "history_event" if item_key in _history_peer_matches(ctx, prov_key, dst_key) else ""
         alias_dest = _alias_peer_key(ctx, prov_key, dst_key, item_key, item)
         if alias_dest:
             return "pair_alias" if _alias_peer_present(ctx, dst_key, alias_dest, item) else ""
-        rewatch = (prov_key, dst_key) in ctx.history_rewatch_pairs
-        if rewatch:
-            dest_items = (ctx.history_keys or {}).get(dst_key) or {}
-            if history_event_present(item, item_key, dest_items, _history_event_tokens, 0):
-                return "history_event"
-            return "anime_coords" if ctx.anime_history_match(prov_key, dst_key, item, require_minute=True) else ""
         exact_keys = _history_exact_keys(item)
         if exact_keys:
             if exact_keys & (ctx.history_exact.get(dst_key) or set()):
@@ -3472,16 +3504,24 @@ def _unresolved_records(allowed_scopes: set[str] | None) -> list[dict[str, Any]]
             if not aks:
                 continue
             reason = str(rec.get("reason") or rec.get("hint") or rec.get("error") or "").strip()
+            raw_reasons = rec.get("reasons")
+            reasons = [str(r) for r in raw_reasons if str(r or "").strip()] if isinstance(raw_reasons, list) else []
+            if reason and reason not in reasons:
+                reasons.insert(0, reason)
+            reason = reason or next(iter(reasons), "")
             records.append(
                 {
                     "provider": prov_key,
                     "feature": feat_key,
                     "key": alias_key,
+                    "event_key": uk,
                     "alias_keys": aks,
                     "ids": dict(item.get("ids") or {}) if isinstance(item, dict) else {},
                     "item": item if isinstance(item, dict) else {},
                     "reason": reason,
-                    "reason_message": _unresolved_reason_message(prov_key, feat_key, [reason]),
+                    "reasons": reasons,
+                    "action": str(rec.get("action") or "").strip().lower(),
+                    "reason_message": _unresolved_reason_message(prov_key, feat_key, reasons),
                     "pending": pending,
                     "retry_blocked": (prov_key, feat_key, uk) in blocked_keys,
                     "file": name,
@@ -3683,6 +3723,28 @@ def _attention_mismatch_rows(problems: Iterable[Mapping[str, Any]]) -> list[dict
     return rows
 
 
+def _history_resolved_unresolved(ctx: _AnalysisContext | None, rec: Mapping[str, Any]) -> bool:
+    if ctx is None or str(rec.get("feature") or "").lower() != "history":
+        return False
+    if is_remove_retry(rec):
+        return False
+    item = rec.get("item")
+    if not isinstance(item, Mapping) or not item:
+        return False
+    # Legacy retry files identify the destination provider, not its account.
+    # Only resolve them when this analysis has a single eligible route.
+    routes = [(src, dst) for src, dst in ctx.history_rewatch_pairs
+              if _provider_base(dst) == _provider_base(rec.get("provider"))]
+    if len(routes) != 1:
+        return False
+    src, dst = routes[0]
+    key = str(rec.get("event_key") or rec.get("key") or "")
+    source_matches = history_event_matches(
+        {key: item}, ctx.history_keys.get(src, {}), _history_event_tokens, tolerance_seconds=0,
+    )
+    return any(source_key in _history_peer_matches(ctx, src, dst) for source_key in source_matches.values())
+
+
 def _anime_resolved_unresolved(ctx: _AnalysisContext | None, rec: Mapping[str, Any]) -> bool:
     if ctx is None:
         return False
@@ -3703,6 +3765,8 @@ def _anime_resolved_unresolved(ctx: _AnalysisContext | None, rec: Mapping[str, A
         for dst_tok in targets:
             if _provider_base(dst_tok) != dst_base:
                 continue
+            if (src_tok, dst_tok) in ctx.history_rewatch_pairs:
+                continue  # Rewatch retries use the shared one-to-one event match.
             if coords.match(src_tok, dst_tok, item):
                 return True
     return False
@@ -3730,8 +3794,12 @@ def _attention_from_analysis(
         ]
 
     anime_resolved = 0
+    history_resolved = 0
     kept: list[dict[str, Any]] = []
     for rec in records:
+        if _history_resolved_unresolved(ctx, rec):
+            history_resolved += 1
+            continue
         if _anime_resolved_unresolved(ctx, rec):
             anime_resolved += 1
             continue
@@ -3740,6 +3808,8 @@ def _attention_from_analysis(
     out = _attention_model(mismatch_rows, kept)
     if anime_resolved:
         out["counts"]["anime_resolved"] = anime_resolved
+    if history_resolved:
+        out["counts"]["history_resolved"] = history_resolved
     return out
 
 

--- a/tests/test_analyzer_history_aliases.py
+++ b/tests/test_analyzer_history_aliases.py
@@ -143,6 +143,18 @@ def test_alias_ignored_when_destination_record_absent(cws) -> None:
     assert stats["synced"] == 0
 
 
+def test_rewatch_alias_requires_the_mapped_destination_even_if_original_exists(cws):
+    item = _episode(12971, 1, 40, series="Dragon Ball Z")
+    key = f"tmdb:12971#s01e40@{WATCHED_EPOCH}"
+    cfg = _cfg(rewatches=True)
+    _write_alias(cws, {key: {
+        "destination_key": "tmdb:12971#s02e01",
+        "destination_event_key": f"tmdb:12971#s02e01@{WATCHED_EPOCH}",
+        "watched_at": WATCHED,
+    }}, scope=pair_feature_scope(cfg, cfg["pairs"][0], "history") + "|SIMKL>TRAKT")
+    assert _synced(_state({key: item}, {key: item}), cfg)["synced"] == 0
+
+
 def test_alias_ignored_when_watched_at_differs_by_more_than_a_minute(cws) -> None:
     simkl = {"tmdb:12971#s01e40": _episode(12971, 1, 40, series="Dragon Ball Z")}
     trakt = {"tmdb:12971#s02e01": _episode(

--- a/tests/test_analyzer_watch_times.py
+++ b/tests/test_analyzer_watch_times.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+import json
 
 import pytest
 
@@ -109,3 +110,86 @@ def test_retry_block_matches_exact_event_and_stays_in_its_scope(watch_pair, monk
     other = A._missing_peer_hints(index, "history", aliases, ["SIMKL"], False, peer_key)
     assert any(h.get("kind") == "blackbox" for h in exact)
     assert not any(h.get("kind") == "blackbox" for h in other)
+
+
+@pytest.mark.parametrize("source_time,target_time", [
+    ("2026-09-12T14:47:12Z", "2026-09-12T14:47:20Z"),
+    ("2026-09-12T14:47:58Z", "2026-09-12T14:48:06Z"),
+    ("2026-09-12T14:47:58Z", "2026-09-12T14:48:58Z"),
+])
+def test_nearby_watch_is_synchronized_in_analysis_attention_and_detail(watch_pair, source_time, target_time):
+    cfg, state, key, peer_key = watch_pair
+    state["providers"]["CROSSWATCH"]["history"]["baseline"]["items"][key]["watched_at"] = source_time
+    state["providers"]["SIMKL"]["history"]["baseline"]["items"][peer_key]["watched_at"] = target_time
+    before = deepcopy(state)
+    save_pair(cfg, state)
+    result = A._cached_analysis("cw-simkl", include_hints=True)
+    assert not any(p["type"] == "missing_peer" for p in result["problems"])
+    assert result["attention"]["counts"]["current_mismatch"] == 0
+    detail = A._detail_for_item("cw-simkl", "CROSSWATCH", "history", key)
+    assert not detail.get("watch_time_differences")
+    assert state == before
+
+
+def test_analyzer_does_not_reuse_a_peer_for_two_viewings(watch_pair):
+    cfg, state, key, peer_key = watch_pair
+    source = state["providers"]["CROSSWATCH"]["history"]["baseline"]["items"]
+    target = state["providers"]["SIMKL"]["history"]["baseline"]["items"]
+    source["extra"] = {**source[key], "watched_at": "2026-09-04T18:12:38Z"}
+    target[peer_key]["watched_at"] = source["extra"]["watched_at"]
+    ctx = A._analysis_context(state, cfg)
+    assert not A._target_has_peer(ctx, "CROSSWATCH", "history", key, source[key], "SIMKL")
+    assert A._target_has_peer(ctx, "CROSSWATCH", "history", "extra", source["extra"], "SIMKL")
+
+
+def test_runtime_tolerance_change_refreshes_cached_analysis_and_detail(watch_pair):
+    cfg, state, key, peer_key = watch_pair
+    save_pair(cfg, state)
+    before = deepcopy(state)
+    # This pair's timestamps differ by 294 seconds. Config changes alone must
+    # invalidate cached matches without fetching or rewriting provider history.
+    for tolerance, expected in ((60, 1), (300, 0), (0, 1)):
+        cfg["runtime"] = {"history_timestamp_tolerance_seconds": tolerance}
+        (A.CONFIG_DIR / "config.json").write_text(json.dumps(cfg), encoding="utf-8")
+        result = A._cached_analysis("cw-simkl", include_hints=True)
+        assert result["attention"]["counts"]["current_mismatch"] == expected
+        assert A._cached_analysis("cw-simkl", include_hints=True)["timings_ms"]["cache_hit"]
+        detail = A._detail_for_item("cw-simkl", "CROSSWATCH", "history", key)
+        assert bool(detail.get("watch_time_differences")) == bool(expected)
+    assert state == before
+
+
+@pytest.mark.parametrize("reason,expected", [
+    ("apply:add:no_confirmations_fallback", 0),
+    ("apply:remove:unconfirmed", 1),
+])
+def test_confirmed_history_match_resolves_only_add_retry_attention(watch_pair, monkeypatch, reason, expected):
+    cfg, state, key, peer_key = watch_pair
+    item = state["providers"]["CROSSWATCH"]["history"]["baseline"]["items"][key]
+    state["providers"]["SIMKL"]["history"]["baseline"]["items"][peer_key]["watched_at"] = "2026-09-04T18:12:38Z"
+    record = dict(provider="SIMKL", feature="history", key=key.split("@")[0], event_key=key,
+                  item=item, alias_keys=A._alias_keys(item), reason=reason)
+    monkeypatch.setattr(A, "_unresolved_records", lambda _scopes: [record])
+    ctx = A._analysis_context(state, cfg)
+    result = A._attention_from_analysis([], set(), ctx)
+    assert result["counts"]["pending_retry"] == expected
+
+
+@pytest.mark.parametrize("metadata,expected", [
+    ({"action": "remove", "reasons": ["write_failed"]}, 1),
+    ({"reasons": ["write_failed", "two:apply:remove:unconfirmed"]}, 1),
+    ({"action": "add", "reasons": ["write_failed"]}, 0),
+    ({"reasons": ["simkl_remove_not_confirmed"]}, 1),
+])
+def test_provider_retry_metadata_is_preserved_in_history_attention(watch_pair, monkeypatch, metadata, expected):
+    cfg, state, key, peer_key = watch_pair
+    item = state["providers"]["CROSSWATCH"]["history"]["baseline"]["items"][key]
+    state["providers"]["SIMKL"]["history"]["baseline"]["items"][peer_key]["watched_at"] = "2026-09-04T18:12:38Z"
+    documents = {"SIMKL_history.unresolved.first.json": {key: {"item": item, **metadata}}}
+    monkeypatch.setattr(A, "_read_cw_state", lambda _scopes: documents)
+    ctx = A._analysis_context(state, cfg)
+    result = A._attention_from_analysis([], {"first"}, ctx)
+    assert result["counts"]["pending_retry"] == expected
+    record = A._unresolved_records({"first"})[0]
+    assert record["reasons"] == metadata["reasons"]
+    assert record.get("action") == metadata.get("action", "")

--- a/tests/test_history_timestamp_tolerance.py
+++ b/tests/test_history_timestamp_tolerance.py
@@ -1,0 +1,301 @@
+from copy import deepcopy
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from cw_platform.history_events import history_sync_key
+from cw_platform.orchestrator._history_rewatches import (
+    history_event_diff, history_event_matches, history_timestamp_tolerance_seconds,
+)
+
+
+def movie(offset=0, **extra):
+    # The eight-second example deliberately crosses a minute boundary.
+    stamp = datetime(2026, 9, 12, 14, 47, 58, tzinfo=timezone.utc) + timedelta(seconds=offset)
+    return dict(type="movie", title="Pressure", ids={"tmdb": "1318413"},
+                watched_at=stamp.isoformat(), **extra)
+
+
+def index(*items):
+    return {history_sync_key(item, event_mode=True): item for item in items}
+
+
+def tokens(item):
+    return {f"{key}:{value}" for key, value in item.get("ids", {}).items()}
+
+
+@pytest.mark.parametrize("gap", [-60, -10, -8, -3, 0, 3, 8, 10, 60])
+def test_nearby_viewings_match_without_changing_records(gap):
+    source, target = index(movie()), index(movie(gap))
+    before = deepcopy((source, target))
+    assert history_event_diff(source, target, tokens) == ([], [])
+    assert (source, target) == before
+
+
+@pytest.mark.parametrize("gap", [-61, 61, 294, 86400])
+def test_separate_viewings_remain_different(gap):
+    adds, removes = history_event_diff(index(movie()), index(movie(gap)), tokens)
+    assert adds[0]["watched_at"] == movie()["watched_at"]
+    assert removes[0]["watched_at"] == movie(gap)["watched_at"]
+
+
+def test_exact_match_reserves_destination_for_one_viewing():
+    source, target = index(movie(), movie(8)), index(movie(8))
+    adds, removes = history_event_diff(source, target, tokens)
+    assert [item["watched_at"] for item in adds] == [movie()["watched_at"]]
+    assert removes == []
+
+
+def test_unique_nearest_pairs_are_symmetric_and_order_independent():
+    source, target = index(movie(), movie(20)), index(movie(8), movie(28))
+    matches = history_event_matches(source, target, tokens)
+    assert matches == {next(iter(index(movie()))): next(iter(index(movie(8)))),
+                       next(iter(index(movie(20)))): next(iter(index(movie(28))))}
+    assert history_event_matches(target, source, tokens) == {v: k for k, v in matches.items()}
+    assert history_event_matches(dict(reversed(list(source.items()))), target, tokens) == matches
+
+
+def test_equidistant_viewings_are_ambiguous():
+    source, target = index(movie(), movie(16)), index(movie(8))
+    assert history_event_matches(source, target, tokens) == {}
+    assert history_event_matches(target, source, tokens) == {}
+
+
+def test_tolerance_does_not_chain_viewings_or_match_other_media():
+    source, target = index(movie(), movie(100)), index(movie(50))
+    assert history_event_matches(source, target, tokens) == {}
+    other_movie = {**movie(8), "ids": {"tmdb": "42"}}
+    other_type = {**movie(8), "type": "show"}
+    assert history_event_matches(index(movie()), index(other_movie, other_type), tokens) == {}
+
+
+def test_exact_comparison_remains_available_for_retry_source_verification():
+    assert history_event_matches(index(movie()), index(movie(8)), tokens, tolerance_seconds=0) == {}
+
+
+def test_sparse_records_still_match_exact_event_keys():
+    key = next(iter(index(movie())))
+    sparse = {"type": "movie", "watched_at": movie()["watched_at"]}
+    assert history_event_matches({key: sparse}, index(movie()), tokens) == {key: key}
+    assert not history_event_matches({key: sparse}, index(movie(8)), tokens)
+
+
+@pytest.mark.parametrize("mode", ["one-way", "two-way"])
+@pytest.mark.parametrize("gap,tolerance", [
+    (8, None), (60, None), (61, None), (300, 300), (301, 300), (0, 0), (8, 0), (8, 5),
+])
+def test_sync_and_preview_use_the_same_history_tolerance(config_base, monkeypatch, mode, gap, tolerance):
+    from cw_platform.orchestrator import Orchestrator
+    from cw_platform.orchestrator._interactive import InteractivePlan
+    from cw_platform.orchestrator._state_store import StateStore
+    from cw_platform.pair_scope import pair_feature_scope
+    from test_interactive_sync_features import feature_setup
+
+    cfg, source, target = feature_setup(config_base, monkeypatch, "history", [], [], mode)
+    if tolerance is not None:
+        cfg.setdefault("runtime", {})["history_timestamp_tolerance_seconds"] = tolerance
+    matched = gap <= (60 if tolerance is None else tolerance)
+    cfg["pairs"][0]["features"]["history"]["rewatches"] = True
+    for ops in (source, target):
+        ops.capabilities = lambda: {"features": {"history": True}, "index_semantics": "present",
+                                   "history": {"rewatches": {"read": True, "write": True}}}
+    source.index, target.index = index(movie()), index(movie(gap))
+    before = deepcopy((source.index, target.index))
+    preview = InteractivePlan()
+    Orchestrator(cfg, interactive=preview).run(dry_run=True, write_state_json=False)
+    assert len(preview.rows) == (0 if matched else (1 if mode == "one-way" else 2))
+    if not matched:
+        execution = InteractivePlan(preview=False, selected=set(preview.rows))
+        Orchestrator(cfg, interactive=execution).run()
+        assert sum(map(len, target.add_calls)) == 1
+        assert sum(map(len, source.add_calls)) == (0 if mode == "one-way" else 1)
+        return
+    # Interactive execution must not reintroduce proposals excluded by the preview.
+    execution = InteractivePlan(preview=False)
+    Orchestrator(cfg, interactive=execution).run()
+    assert not execution.rows
+    assert not source.add_calls and not target.add_calls
+    result = Orchestrator(cfg).run()
+    assert not result["errors"]
+    assert not source.add_calls and not target.add_calls
+    assert (source.index, target.index) == before
+    scope = pair_feature_scope(cfg, cfg["pairs"][0], "history", 1)
+    state = StateStore(config_base).for_pair(scope).load_state_features({"history"})
+    for name, expected in zip(("SRC", "DST"), before):
+        stored = state["providers"][name]["history"]["baseline"]["items"]
+        assert {row["watched_at"] for row in stored.values()} == {row["watched_at"] for row in expected.values()}
+
+
+@pytest.mark.parametrize("value,expected", [
+    (0, 0), (300, 300), (" 120 ", 120), (-1, 0), (None, 60),
+    (True, 60), (False, 60), ("bad", 60), (1.5, 60), ({}, 60),
+])
+def test_runtime_history_tolerance_values(value, expected):
+    assert history_timestamp_tolerance_seconds({"runtime": {"history_timestamp_tolerance_seconds": value}}) == expected
+
+
+def test_history_tolerance_config_roundtrip(config_base):
+    from cw_platform.config_base import load_config, save_config
+
+    cfg = load_config()
+    assert cfg["runtime"]["history_timestamp_tolerance_seconds"] == 60
+    for value in (300, 0):
+        cfg["runtime"]["history_timestamp_tolerance_seconds"] = value
+        save_config(cfg)
+        assert history_timestamp_tolerance_seconds(load_config()) == value
+
+
+def test_retry_cleanup_preserves_other_events_removals_and_pair_scopes(tmp_path, monkeypatch):
+    from cw_platform.orchestrator import _unresolved as unresolved
+
+    monkeypatch.setattr(unresolved, "STATE_DIR", tmp_path)
+    first, second, deletion = [next(iter(index(movie(offset)))) for offset in (0, 8, 20)]
+    for scope in ("cw2_test_a", "cw2_test_b"):
+        monkeypatch.setenv("CW_PAIR_SCOPE", scope)
+        unresolved.record_unresolved("SIMKL", "history", [first, second], hint="apply:add:no_confirmations_fallback")
+        unresolved.record_unresolved("SIMKL", "history", [deletion], hint="apply:remove:unconfirmed")
+    monkeypatch.setenv("CW_PAIR_SCOPE", "cw2_test_a")
+    assert unresolved.clear_matched_history_retries("SIMKL", [first, deletion]) == {first: first}
+    assert set(unresolved.load_unresolved_map("SIMKL", "history", cross_features=False)) == {second, deletion}
+    monkeypatch.setenv("CW_PAIR_SCOPE", "cw2_test_b")
+    assert set(unresolved.load_unresolved_map("SIMKL", "history", cross_features=False)) == {first, second, deletion}
+
+
+def test_legacy_retry_cleanup_uses_the_recorded_viewing_time(tmp_path, monkeypatch):
+    from cw_platform.orchestrator import _unresolved as unresolved
+
+    monkeypatch.setattr(unresolved, "STATE_DIR", tmp_path)
+    monkeypatch.setenv("CW_PAIR_SCOPE", "cw2_legacy_test")
+    unresolved.record_unresolved("SIMKL", "history", [movie()], hint="apply:add:no_confirmations_fallback")
+    # A different viewing of the same title is not evidence that this retry succeeded.
+    assert not unresolved.clear_matched_history_retries("SIMKL", index(movie(8)))
+    assert unresolved.clear_matched_history_retries("SIMKL", index(movie())) == {"tmdb:1318413": next(iter(index(movie())))}
+    assert not unresolved.load_unresolved_pending("SIMKL", "history")
+
+
+@pytest.mark.parametrize("pending", [False, True])
+@pytest.mark.parametrize("metadata", [
+    {"action": "remove", "reasons": ["write_failed"]},
+    {"reasons": ["write_failed", "two:apply:remove:unconfirmed"]},
+    {"hint": "simkl_remove_not_confirmed"},
+    {"reason": "trakt_history_remove_unconfirmed"},
+])
+def test_provider_removal_retry_survives_presence_confirmation(tmp_path, monkeypatch, pending, metadata):
+    import json
+    from cw_platform.orchestrator import _unresolved as unresolved
+
+    monkeypatch.setattr(unresolved, "STATE_DIR", tmp_path)
+    monkeypatch.setenv("CW_PAIR_SCOPE", "cw2_provider_removal")
+    key = next(iter(index(movie())))
+    row = {"feature": "history", "item": movie(), **metadata}
+    path = unresolved._blocking_path("SIMKL", "history")
+    path.write_text(json.dumps({key: row}), encoding="utf-8")
+    if pending:
+        unresolved.record_unresolved("SIMKL", "history", [key], hint="apply:add:failed")
+    assert unresolved.clear_matched_history_retries("SIMKL", [key]) == {}
+    assert json.loads(path.read_text(encoding="utf-8")) == {key: row}
+    if pending:
+        assert unresolved.load_unresolved_pending("SIMKL", "history")
+
+
+@pytest.mark.parametrize("mode", ["one-way", "two-way"])
+def test_retry_confirmation_uses_original_matched_event_keys(config_base, monkeypatch, mode):
+    from cw_platform.orchestrator import Orchestrator, _pairs_oneway, _pairs_twoway
+    from cw_platform.orchestrator._interactive import InteractivePlan
+    from test_interactive_sync_features import feature_setup
+
+    cfg, source, target = feature_setup(config_base, monkeypatch, "history", [], [], mode)
+    cfg["pairs"][0]["features"]["history"]["rewatches"] = True
+    for ops in (source, target):
+        ops.capabilities = lambda: {"features": {"history": True}, "index_semantics": "present",
+                                   "history": {"rewatches": {"read": True, "write": True}}}
+    # Preserve provider event-ID keys even when a watch timestamp is available.
+    source.index = {"tmdb:1318413@id:998877": movie(), "tmdb:1318413@id:998878": movie(1000)}
+    target.index = {"tmdb:1318413@id:123456": movie(8), "tmdb:1318413@id:123457": movie(2000)}
+    cleared = []
+
+    def clear(provider, keys):
+        cleared.append((provider, set(keys)))
+        return {}
+
+    for module in (_pairs_oneway, _pairs_twoway):
+        monkeypatch.setattr(module, "clear_matched_history_retries", clear)
+    # Execute without selecting the unmatched additions; only existing peer
+    # matches can confirm retries, regardless of provider write outcomes.
+    result = Orchestrator(cfg, interactive=InteractivePlan(preview=False)).run()
+    assert not result["errors"]
+    assert ("DST", {"tmdb:1318413@id:998877"}) in cleared
+    if mode == "two-way":
+        assert ("SRC", {"tmdb:1318413@id:123456"}) in cleared
+    assert all(len(keys) == 1 for _, keys in cleared)
+
+
+@pytest.mark.parametrize("mode", ["one-way", "two-way"])
+def test_sync_clears_confirmed_retry_only_during_execution(config_base, monkeypatch, mode):
+    from cw_platform.orchestrator import Orchestrator, _pairs_oneway, _pairs_twoway
+    from cw_platform.orchestrator._interactive import InteractivePlan
+    from test_interactive_sync_features import feature_setup
+
+    cfg, source, target = feature_setup(config_base, monkeypatch, "history", [], [], mode)
+    cfg["pairs"][0]["features"]["history"]["rewatches"] = True
+    for ops in (source, target):
+        ops.capabilities = lambda: {"features": {"history": True}, "index_semantics": "present",
+                                   "history": {"rewatches": {"read": True, "write": True}}}
+    source.index, target.index = index(movie()), index(movie(8))
+    cleared = []
+
+    def clear(provider, keys):
+        cleared.append((provider, set(keys)))
+        return {key: key for key in keys}
+
+    for module in (_pairs_oneway, _pairs_twoway):
+        monkeypatch.setattr(module, "clear_matched_history_retries", clear)
+    Orchestrator(cfg, interactive=InteractivePlan()).run(dry_run=True, write_state_json=False)
+    assert not cleared
+    result = Orchestrator(cfg).run()
+    assert not result["errors"]
+    assert ("DST", set(source.index)) in cleared
+    if mode == "two-way":
+        assert ("SRC", set(target.index)) in cleared
+    assert not source.add_calls and not target.add_calls
+
+
+@pytest.mark.parametrize("mode", ["one-way", "two-way"])
+@pytest.mark.parametrize("retry_key", ["base", "event"])
+def test_confirmed_retry_archive_preserves_item_metadata(config_base, monkeypatch, mode, retry_key):
+    from cw_platform.event_archive.db import connect
+    from cw_platform.orchestrator import Orchestrator, _unresolved as unresolved
+    from cw_platform.pair_scope import pair_feature_scope
+    from test_interactive_sync_features import feature_setup
+
+    cfg, source, target = feature_setup(config_base, monkeypatch, "history", [], [], mode)
+    cfg["pairs"][0]["features"]["history"]["rewatches"] = True
+    for ops in (source, target):
+        ops.capabilities = lambda: {"features": {"history": True}, "index_semantics": "present",
+                                   "history": {"rewatches": {"read": True, "write": True}}}
+    source.index, target.index = index(movie()), index(movie(8))
+    scope = pair_feature_scope(cfg, cfg["pairs"][0], "history", 1)
+    monkeypatch.setenv("CW_PAIR_SCOPE", scope)
+    destinations = {"DST": source.index}
+    if mode == "two-way":
+        destinations["SRC"] = target.index
+    for provider, items in destinations.items():
+        payload = items.values() if retry_key == "base" else items.keys()
+        unresolved.record_unresolved(provider, "history", payload, hint="apply:add:failed")
+
+    conn = connect(":memory:")
+    monkeypatch.setattr("cw_platform.event_archive.recorder.get_conn", lambda: conn)
+    try:
+        result = Orchestrator(cfg).run()
+        assert not result["errors"]
+        rows = conn.execute("SELECT destination_provider, item_key, title, media_type, match_basis "
+                            "FROM events WHERE event_type='unresolved_cleared'").fetchall()
+        assert len(rows) == len(destinations)
+        for provider, key, title, media_type, match_basis in rows:
+            expected_key = "tmdb:1318413" if retry_key == "base" else next(iter(destinations[provider]))
+            assert key == expected_key
+            assert (title, media_type, match_basis) == ("Pressure", "movie", "tmdb:1318413")
+            assert not unresolved.load_unresolved_pending(provider, "history")
+        assert not source.add_calls and not target.add_calls
+    finally:
+        conn.close()


### PR DESCRIPTION
# Pull request

## Change

- Add `runtime.history_timestamp_tolerance_seconds`, defaulting to 60 seconds. 
- Shared across one-way, two-way and interactive sync, plus the analyzer.
- Keep original timestamps and match viewings one-to-one. 
- Clear confirmed add retries while preserving removal retries and Events archive metadata.

## Why

- Providers can timestamp the same viewing a few seconds apart, causing false warnings and unnecessary history writes.

## Testing
Local tests passed.

## Issue
Relates to #1102